### PR TITLE
Improved Lat/Long precision and accuracy

### DIFF
--- a/Adafruit_GPS.cpp
+++ b/Adafruit_GPS.cpp
@@ -9,7 +9,7 @@ Written by Limor Fried/Ladyada for Adafruit Industries.
 BSD license, check license.txt for more information
 All text above must be included in any redistribution
 ****************************************/
-
+#include <SoftwareSerial.h>
 #include <Adafruit_GPS.h>
 
 // how long are max NMEA lines to parse?
@@ -44,7 +44,7 @@ boolean Adafruit_GPS::parse(char *nmea) {
       //return false;
     }
   }
-
+  char degreebuff[10];
   // look for a few common sentences
   if (strstr(nmea, "$GPGGA")) {
     // found GGA
@@ -61,7 +61,16 @@ boolean Adafruit_GPS::parse(char *nmea) {
 
     // parse out latitude
     p = strchr(p, ',')+1;
-    latitude = atof(p);
+    strncpy(degreebuff, p, 2);
+    p += 2;
+    degreebuff[2] = '\0';
+    int32_t degree = atol(degreebuff) * 10000000;
+    strncpy(degreebuff, p, 2); // minutes
+    p += 3; // skip decimal point
+    strncpy(degreebuff + 2, p, 4);
+    degreebuff[6] = '\0';
+    long minutes = 50 * atol(degreebuff) / 3;
+    latitude = degree + minutes;
 
     p = strchr(p, ',')+1;
     if (p[0] == 'N') lat = 'N';
@@ -71,7 +80,16 @@ boolean Adafruit_GPS::parse(char *nmea) {
 
     // parse out longitude
     p = strchr(p, ',')+1;
-    longitude = atof(p);
+    strncpy(degreebuff, p, 3);
+    p += 3;
+    degreebuff[3] = '\0';
+    degree = atol(degreebuff) * 10000000;
+    strncpy(degreebuff, p, 2); // minutes
+    p += 3; // skip decimal point
+    strncpy(degreebuff + 2, p, 4);
+    degreebuff[6] = '\0';
+    minutes = 50 * atol(degreebuff) / 3;
+    longitude = degree + minutes;
 
     p = strchr(p, ',')+1;
     if (p[0] == 'W') lon = 'W';
@@ -120,7 +138,16 @@ boolean Adafruit_GPS::parse(char *nmea) {
 
     // parse out latitude
     p = strchr(p, ',')+1;
-    latitude = atof(p);
+    strncpy(degreebuff, p, 2);
+    p += 2;
+    degreebuff[2] = '\0';
+    long degree = atol(degreebuff) * 10000000;
+    strncpy(degreebuff, p, 2); // minutes
+    p += 3; // skip decimal point
+    strncpy(degreebuff + 2, p, 4);
+    degreebuff[6] = '\0';
+    long minutes = 50 * atol(degreebuff) / 3;
+    latitude = degree + minutes;
 
     p = strchr(p, ',')+1;
     if (p[0] == 'N') lat = 'N';
@@ -130,7 +157,16 @@ boolean Adafruit_GPS::parse(char *nmea) {
 
     // parse out longitude
     p = strchr(p, ',')+1;
-    longitude = atof(p);
+    strncpy(degreebuff, p, 3);
+    p += 3;
+    degreebuff[3] = '\0';
+    degree = atol(degreebuff) * 10000000;
+    strncpy(degreebuff, p, 2); // minutes
+    p += 3; // skip decimal point
+    strncpy(degreebuff + 2, p, 4);
+    degreebuff[6] = '\0';
+    minutes = 50 * atol(degreebuff) / 3;
+    longitude = degree + minutes;
 
     p = strchr(p, ',')+1;
     if (p[0] == 'W') lon = 'W';

--- a/Adafruit_GPS.h
+++ b/Adafruit_GPS.h
@@ -54,6 +54,9 @@ All text above must be included in any redistribution
 #define LOCUS_OVERLAP 0
 #define LOCUS_FULLSTOP 1
 
+#define PMTK_ENABLE_SBAS "$PMTK313,1*2E"
+#define PMTK_ENABLE_WAAS "$PMTK301,2*2E"
+
 // standby command & boot successful message
 #define PMTK_STANDBY "$PMTK161,0*28"
 #define PMTK_STANDBY_SUCCESS "$PMTK001,161,3*3"  // Not needed currently
@@ -105,7 +108,8 @@ class Adafruit_GPS {
 
   uint8_t hour, minute, seconds, year, month, day;
   uint16_t milliseconds;
-  float latitude, longitude, geoidheight, altitude;
+  int32_t latitude, longitude;
+  float geoidheight, altitude;
   float speed, angle, magvariation, HDOP;
   char lat, lon, mag;
   boolean fix;


### PR DESCRIPTION
I patched the base code to use longs rather than floats for lat/long, and to put them in the correct format (lat/long are in units of 1/10,000,000 of a degree with the minutes converted to 1/100,000 of a degree). Using a common integer format is more accurate, and using longs instead of floats is both faster and more precise. I'm uploading some geo-fencing code to GitHub that uses this version of the library and is much faster and extremely precise with WAAS enabled (within 3m). 

For example, the library would return a lat/long of approximately 407,098,514N / 740,079,168W for AdaFruit HQ. 
