### PR TITLE
Use USART interrupt

### DIFF
--- a/Adafruit_GPS.h
+++ b/Adafruit_GPS.h
@@ -24,54 +24,54 @@ All text above must be included in any redistribution
 // different commands to set the update rate from once a second (1 Hz) to 10 times a second (10Hz)
 // Note that these only control the rate at which the position is echoed, to actually speed up the
 // position fix you must also send one of the position fix rate commands below too.
-#define PMTK_SET_NMEA_UPDATE_100_MILLIHERTZ  "$PMTK220,10000*2F" // Once every 10 seconds, 100 millihertz.
-#define PMTK_SET_NMEA_UPDATE_1HZ  "$PMTK220,1000*1F"
-#define PMTK_SET_NMEA_UPDATE_5HZ  "$PMTK220,200*2C"
-#define PMTK_SET_NMEA_UPDATE_10HZ "$PMTK220,100*2F"
+#define PMTK_SET_NMEA_UPDATE_100_MILLIHERTZ  "$PMTK220,10000*2F\r\n" // Once every 10 seconds, 100 millihertz.
+#define PMTK_SET_NMEA_UPDATE_1HZ  "$PMTK220,1000*1F\r\n"
+#define PMTK_SET_NMEA_UPDATE_5HZ  "$PMTK220,200*2C\r\n"
+#define PMTK_SET_NMEA_UPDATE_10HZ "$PMTK220,100*2F\r\n"
 // Position fix update rate commands.
-#define PMTK_API_SET_FIX_CTL_100_MILLIHERTZ  "$PMTK300,10000,0,0,0,0*2C" // Once every 10 seconds, 100 millihertz.
-#define PMTK_API_SET_FIX_CTL_1HZ  "$PMTK300,1000,0,0,0,0*1C"
-#define PMTK_API_SET_FIX_CTL_5HZ  "$PMTK300,200,0,0,0,0*2F"
+#define PMTK_API_SET_FIX_CTL_100_MILLIHERTZ  "$PMTK300,10000,0,0,0,0*2C\r\n" // Once every 10 seconds, 100 millihertz.
+#define PMTK_API_SET_FIX_CTL_1HZ  "$PMTK300,1000,0,0,0,0*1C\r\n"
+#define PMTK_API_SET_FIX_CTL_5HZ  "$PMTK300,200,0,0,0,0*2F\r\n"
 // Can't fix position faster than 5 times a second!
 
 
-#define PMTK_SET_BAUD_57600 "$PMTK251,57600*2C"
-#define PMTK_SET_BAUD_9600 "$PMTK251,9600*17"
+#define PMTK_SET_BAUD_57600 "$PMTK251,57600*2C\r\n"
+#define PMTK_SET_BAUD_9600 "$PMTK251,9600*17\r\n"
 
 // turn on only the second sentence (GPRMC)
-#define PMTK_SET_NMEA_OUTPUT_RMCONLY "$PMTK314,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0*29"
+#define PMTK_SET_NMEA_OUTPUT_RMCONLY "$PMTK314,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0*29\r\n"
 // turn on GPRMC and GGA
-#define PMTK_SET_NMEA_OUTPUT_RMCGGA "$PMTK314,0,1,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0*28"
+#define PMTK_SET_NMEA_OUTPUT_RMCGGA "$PMTK314,0,1,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0*28\r\n"
 // turn on ALL THE DATA
-#define PMTK_SET_NMEA_OUTPUT_ALLDATA "$PMTK314,1,1,1,1,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0*28"
+#define PMTK_SET_NMEA_OUTPUT_ALLDATA "$PMTK314,1,1,1,1,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0*28\r\n"
 // turn off output
-#define PMTK_SET_NMEA_OUTPUT_OFF "$PMTK314,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0*28"
+#define PMTK_SET_NMEA_OUTPUT_OFF "$PMTK314,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0*28\r\n"
 
 // to generate your own sentences, check out the MTK command datasheet and use a checksum calculator
 // such as the awesome http://www.hhhh.org/wiml/proj/nmeaxor.html
 
-#define PMTK_LOCUS_STARTLOG  "$PMTK185,0*22"
-#define PMTK_LOCUS_STOPLOG "$PMTK185,1*23"
-#define PMTK_LOCUS_STARTSTOPACK "$PMTK001,185,3*3C"
-#define PMTK_LOCUS_QUERY_STATUS "$PMTK183*38"
-#define PMTK_LOCUS_ERASE_FLASH "$PMTK184,1*22"
+#define PMTK_LOCUS_STARTLOG  "$PMTK185,0*22\r\n"
+#define PMTK_LOCUS_STOPLOG "$PMTK185,1*23\r\n"
+#define PMTK_LOCUS_STARTSTOPACK "$PMTK001,185,3*3C\r\n"
+#define PMTK_LOCUS_QUERY_STATUS "$PMTK183*38\r\n"
+#define PMTK_LOCUS_ERASE_FLASH "$PMTK184,1*22\r\n"
 #define LOCUS_OVERLAP 0
 #define LOCUS_FULLSTOP 1
 
-#define PMTK_ENABLE_SBAS "$PMTK313,1*2E"
-#define PMTK_ENABLE_WAAS "$PMTK301,2*2E"
+#define PMTK_ENABLE_SBAS "$PMTK313,1*2E\r\n"
+#define PMTK_ENABLE_WAAS "$PMTK301,2*2E\r\n"
 
 // standby command & boot successful message
-#define PMTK_STANDBY "$PMTK161,0*28"
-#define PMTK_STANDBY_SUCCESS "$PMTK001,161,3*36"  // Not needed currently
-#define PMTK_AWAKE "$PMTK010,002*2D"
+#define PMTK_STANDBY "$PMTK161,0*28\r\n"
+#define PMTK_STANDBY_SUCCESS "$PMTK001,161,3*36\r\n"  // Not needed currently
+#define PMTK_AWAKE "$PMTK010,002*2D\r\n"
 
 // ask for the release and version
-#define PMTK_Q_RELEASE "$PMTK605*31"
+#define PMTK_Q_RELEASE "$PMTK605*31\r\n"
 
 // request for updates on antenna status 
-#define PGCMD_ANTENNA "$PGCMD,33,1*6C" 
-#define PGCMD_NOANTENNA "$PGCMD,33,0*6D" 
+#define PGCMD_ANTENNA "$PGCMD,33,1*6C\r\n" 
+#define PGCMD_NOANTENNA "$PGCMD,33,0*6D\r\n" 
 
 // how long to wait when we're looking for a response
 #define MAXWAITSENTENCE 5
@@ -91,7 +91,7 @@ class Adafruit_GPS {
   char *lastNMEA(void);
   boolean newNMEAreceived();
 
-  void sendCommand(const char *);
+  void sendCommand(char *);
   
   void pause(boolean b);
 
@@ -130,6 +130,9 @@ class Adafruit_GPS {
   uint8_t LOCUS_type, LOCUS_mode, LOCUS_config, LOCUS_interval, LOCUS_distance, LOCUS_speed, LOCUS_status, LOCUS_percent;
  private:
   boolean paused;
+  char* txstr;
+  volatile uint8_t txindex;
+  volatile bool _written;
   
   uint8_t parseResponse(char *response);
 

--- a/Adafruit_GPS.h
+++ b/Adafruit_GPS.h
@@ -21,14 +21,6 @@ All text above must be included in any redistribution
 #ifndef _ADAFRUIT_GPS_H
 #define _ADAFRUIT_GPS_H
 
-#ifdef __AVR__
-  #if ARDUINO >= 100
-    #include <SoftwareSerial.h>
-  #else
-    #include <NewSoftSerial.h>
-  #endif
-#endif
-
 // different commands to set the update rate from once a second (1 Hz) to 10 times a second (10Hz)
 // Note that these only control the rate at which the position is echoed, to actually speed up the
 // position fix you must also send one of the position fix rate commands below too.
@@ -84,33 +76,20 @@ All text above must be included in any redistribution
 // how long to wait when we're looking for a response
 #define MAXWAITSENTENCE 5
 
-#if ARDUINO >= 100
- #include "Arduino.h"
-#if defined (__AVR__) && !defined(__AVR_ATmega32U4__)
- #include "SoftwareSerial.h"
-#endif
-#else
- #include "WProgram.h"
- #include "NewSoftSerial.h"
-#endif
-
+#include "Arduino.h"
+#include "wiring_private.h"
 
 class Adafruit_GPS {
  public:
-  void begin(uint16_t baud); 
+  void begin(unsigned long baud); 
 
-#ifdef __AVR__
-  #if ARDUINO >= 100 
-    Adafruit_GPS(SoftwareSerial *ser); // Constructor when using SoftwareSerial
-  #else
-    Adafruit_GPS(NewSoftSerial  *ser); // Constructor when using NewSoftSerial
-  #endif
-#endif
-  Adafruit_GPS(HardwareSerial *ser); // Constructor when using HardwareSerial
+  Adafruit_GPS(
+      volatile uint8_t *ubrrh, volatile uint8_t *ubrrl,
+      volatile uint8_t *ucsra, volatile uint8_t *ucsrb,
+      volatile uint8_t *ucsrc, volatile uint8_t *udr);
 
   char *lastNMEA(void);
   boolean newNMEAreceived();
-  void common_init(void);
 
   void sendCommand(const char *);
   
@@ -120,6 +99,7 @@ class Adafruit_GPS {
   uint8_t parseHex(char c);
 
   char read(void);
+  void write(void);
   boolean parse(char *);
   void interruptReads(boolean r);
 
@@ -152,14 +132,13 @@ class Adafruit_GPS {
   boolean paused;
   
   uint8_t parseResponse(char *response);
-#ifdef __AVR__
-  #if ARDUINO >= 100
-    SoftwareSerial *gpsSwSerial;
-  #else
-    NewSoftSerial  *gpsSwSerial;
-  #endif
-#endif
-  HardwareSerial *gpsHwSerial;
+
+  volatile uint8_t * const _ubrrh;
+  volatile uint8_t * const _ubrrl;
+  volatile uint8_t * const _ucsra;
+  volatile uint8_t * const _ucsrb;
+  volatile uint8_t * const _ucsrc;
+  volatile uint8_t * const _udr;
 };
 
 


### PR DESCRIPTION
The current recommended approach to parse NMEA messages is to use a timer interrupt that polls the hardware serial for data.
While I did not observe any real problem with this approach, it seems wasteful.

This patch breaks everything, but avoids HardwareSerial entirely, using its own USART interrupt.
Since Arduino 1.5.x, not referring to `SerialN` means the buffer and interrupt are not instantiated.
So this frees up a few CPU cycles and 128 bytes of SRAM.

Usage on the Mega is as follows

``` C++
// copy from HardwareSerialN.cpp
Adafruit_GPS GPS(&UBRR2H, &UBRR2L, &UCSR2A, &UCSR2B, &UCSR2C, &UDR2);

ISR(USART2_RX_vect)
{
  GPS.read();
}

ISR(USART2_UDRE_vect)
{
  GPS.write();
}

void setup()
{
  GPS.begin(9600);
}
```

If there is any interest, I can try to make it backwards compatible.
