### PR TITLE
Fix begin function on non-AVR architecture

### DIFF
--- a/Adafruit_GPS.cpp
+++ b/Adafruit_GPS.cpp
@@ -356,8 +356,8 @@ void Adafruit_GPS::begin(uint16_t baud)
   if(gpsSwSerial) 
     gpsSwSerial->begin(baud);
   else 
-    gpsHwSerial->begin(baud);
 #endif
+    gpsHwSerial->begin(baud);
 
   delay(10);
 }

--- a/Adafruit_GPS.cpp
+++ b/Adafruit_GPS.cpp
@@ -37,8 +37,8 @@ boolean Adafruit_GPS::parse(char *nmea) {
   if (nmea[strlen(nmea)-4] == '*') {
     uint16_t sum = parseHex(nmea[strlen(nmea)-3]) * 16;
     sum += parseHex(nmea[strlen(nmea)-2]);
-    
-    // check checksum 
+
+    // check checksum
     for (uint8_t i=2; i < (strlen(nmea)-4); i++) {
       sum ^= nmea[i];
     }
@@ -82,7 +82,7 @@ boolean Adafruit_GPS::parse(char *nmea) {
       latitudeDegrees = (latitude-100*int(latitude/100))/60.0;
       latitudeDegrees += int(latitude/100);
     }
-    
+
     p = strchr(p, ',')+1;
     if (',' != *p)
     {
@@ -92,7 +92,7 @@ boolean Adafruit_GPS::parse(char *nmea) {
       else if (p[0] == ',') lat = 0;
       else return false;
     }
-    
+
     // parse out longitude
     p = strchr(p, ',')+1;
     if (',' != *p)
@@ -111,7 +111,7 @@ boolean Adafruit_GPS::parse(char *nmea) {
       longitudeDegrees = (longitude-100*int(longitude/100))/60.0;
       longitudeDegrees += int(longitude/100);
     }
-    
+
     p = strchr(p, ',')+1;
     if (',' != *p)
     {
@@ -121,31 +121,31 @@ boolean Adafruit_GPS::parse(char *nmea) {
       else if (p[0] == ',') lon = 0;
       else return false;
     }
-    
+
     p = strchr(p, ',')+1;
     if (',' != *p)
     {
       fixquality = atoi(p);
     }
-    
+
     p = strchr(p, ',')+1;
     if (',' != *p)
     {
       satellites = atoi(p);
     }
-    
+
     p = strchr(p, ',')+1;
     if (',' != *p)
     {
       HDOP = atof(p);
     }
-    
+
     p = strchr(p, ',')+1;
     if (',' != *p)
     {
       altitude = atof(p);
     }
-    
+
     p = strchr(p, ',')+1;
     p = strchr(p, ',')+1;
     if (',' != *p)
@@ -170,7 +170,7 @@ boolean Adafruit_GPS::parse(char *nmea) {
 
     p = strchr(p, ',')+1;
     // Serial.println(p);
-    if (p[0] == 'A') 
+    if (p[0] == 'A')
       fix = true;
     else if (p[0] == 'V')
       fix = false;
@@ -195,7 +195,7 @@ boolean Adafruit_GPS::parse(char *nmea) {
       latitudeDegrees = (latitude-100*int(latitude/100))/60.0;
       latitudeDegrees += int(latitude/100);
     }
-    
+
     p = strchr(p, ',')+1;
     if (',' != *p)
     {
@@ -205,7 +205,7 @@ boolean Adafruit_GPS::parse(char *nmea) {
       else if (p[0] == ',') lat = 0;
       else return false;
     }
-    
+
     // parse out longitude
     p = strchr(p, ',')+1;
     if (',' != *p)
@@ -224,7 +224,7 @@ boolean Adafruit_GPS::parse(char *nmea) {
       longitudeDegrees = (longitude-100*int(longitude/100))/60.0;
       longitudeDegrees += int(longitude/100);
     }
-    
+
     p = strchr(p, ',')+1;
     if (',' != *p)
     {
@@ -240,14 +240,14 @@ boolean Adafruit_GPS::parse(char *nmea) {
     {
       speed = atof(p);
     }
-    
+
     // angle
     p = strchr(p, ',')+1;
     if (',' != *p)
     {
       angle = atof(p);
     }
-    
+
     p = strchr(p, ',')+1;
     if (',' != *p)
     {
@@ -265,14 +265,14 @@ boolean Adafruit_GPS::parse(char *nmea) {
 
 char Adafruit_GPS::read(void) {
   char c = 0;
-  
+
   if (paused) return c;
 
 #ifdef __AVR__
   if(gpsSwSerial) {
     if(!gpsSwSerial->available()) return c;
     c = gpsSwSerial->read();
-  } else 
+  } else
 #endif
   {
     if(!gpsHwSerial->available()) return c;
@@ -315,7 +315,7 @@ char Adafruit_GPS::read(void) {
 #if ARDUINO >= 100
 Adafruit_GPS::Adafruit_GPS(SoftwareSerial *ser)
 #else
-Adafruit_GPS::Adafruit_GPS(NewSoftSerial *ser) 
+Adafruit_GPS::Adafruit_GPS(NewSoftSerial *ser)
 #endif
 {
   common_init();     // Set everything to common state, then...
@@ -353,9 +353,9 @@ void Adafruit_GPS::common_init(void) {
 void Adafruit_GPS::begin(uint16_t baud)
 {
 #ifdef __AVR__
-  if(gpsSwSerial) 
+  if(gpsSwSerial)
     gpsSwSerial->begin(baud);
-  else 
+  else
 #endif
     gpsHwSerial->begin(baud);
 
@@ -364,9 +364,9 @@ void Adafruit_GPS::begin(uint16_t baud)
 
 void Adafruit_GPS::sendCommand(const char *str) {
 #ifdef __AVR__
-  if(gpsSwSerial) 
+  if(gpsSwSerial)
     gpsSwSerial->println(str);
-  else    
+  else
 #endif
     gpsHwSerial->println(str);
 }
@@ -403,7 +403,7 @@ boolean Adafruit_GPS::waitForSentence(const char *wait4me, uint8_t max) {
 
   uint8_t i=0;
   while (i < max) {
-    if (newNMEAreceived()) { 
+    if (newNMEAreceived()) {
       char *nmea = lastNMEA();
       strncpy(str, nmea, 20);
       str[19] = 0;
@@ -431,23 +431,23 @@ boolean Adafruit_GPS::LOCUS_StopLogger(void) {
 
 boolean Adafruit_GPS::LOCUS_ReadStatus(void) {
   sendCommand(PMTK_LOCUS_QUERY_STATUS);
-  
+
   if (! waitForSentence("$PMTKLOG"))
     return false;
 
   char *response = lastNMEA();
   uint16_t parsed[10];
   uint8_t i;
-  
+
   for (i=0; i<10; i++) parsed[i] = -1;
-  
+
   response = strchr(response, ',');
   for (i=0; i<10; i++) {
-    if (!response || (response[0] == 0) || (response[0] == '*')) 
+    if (!response || (response[0] == 0) || (response[0] == '*'))
       break;
     response++;
     parsed[i]=0;
-    while ((response[0] != ',') && 
+    while ((response[0] != ',') &&
 	   (response[0] != '*') && (response[0] != 0)) {
       parsed[i] *= 10;
       char c = response[0];
@@ -461,7 +461,7 @@ boolean Adafruit_GPS::LOCUS_ReadStatus(void) {
   LOCUS_serial = parsed[0];
   LOCUS_type = parsed[1];
   if (isAlpha(parsed[2])) {
-    parsed[2] = parsed[2] - 'a' + 10; 
+    parsed[2] = parsed[2] - 'a' + 10;
   }
   LOCUS_mode = parsed[2];
   LOCUS_config = parsed[3];

--- a/Adafruit_GPS.h
+++ b/Adafruit_GPS.h
@@ -5,18 +5,18 @@ for the ultimate GPS module!
 Tested and works great with the Adafruit Ultimate GPS module
 using MTK33x9 chipset
     ------> http://www.adafruit.com/products/746
-Pick one up today at the Adafruit electronics shop 
+Pick one up today at the Adafruit electronics shop
 and help support open source hardware & software! -ada
 
-Adafruit invests time and resources providing this open source code, 
-please support Adafruit and open-source hardware by purchasing 
+Adafruit invests time and resources providing this open source code,
+please support Adafruit and open-source hardware by purchasing
 products from Adafruit!
 
-Written by Limor Fried/Ladyada  for Adafruit Industries.  
+Written by Limor Fried/Ladyada  for Adafruit Industries.
 BSD license, check license.txt for more information
 All text above must be included in any redistribution
 ****************************************/
-// Fllybob added lines 34,35 and 40,41 to add 100mHz logging capability 
+// Fllybob added lines 34,35 and 40,41 to add 100mHz logging capability
 
 #ifndef _ADAFRUIT_GPS_H
 #define _ADAFRUIT_GPS_H
@@ -79,9 +79,9 @@ All text above must be included in any redistribution
 // ask for the release and version
 #define PMTK_Q_RELEASE "$PMTK605*31"
 
-// request for updates on antenna status 
-#define PGCMD_ANTENNA "$PGCMD,33,1*6C" 
-#define PGCMD_NOANTENNA "$PGCMD,33,0*6D" 
+// request for updates on antenna status
+#define PGCMD_ANTENNA "$PGCMD,33,1*6C"
+#define PGCMD_NOANTENNA "$PGCMD,33,0*6D"
 
 // how long to wait when we're looking for a response
 #define MAXWAITSENTENCE 5
@@ -99,10 +99,10 @@ All text above must be included in any redistribution
 
 class Adafruit_GPS {
  public:
-  void begin(uint16_t baud); 
+  void begin(uint16_t baud);
 
 #ifdef __AVR__
-  #if ARDUINO >= 100 
+  #if ARDUINO >= 100
     Adafruit_GPS(SoftwareSerial *ser); // Constructor when using SoftwareSerial
   #else
     Adafruit_GPS(NewSoftSerial  *ser); // Constructor when using NewSoftSerial
@@ -115,7 +115,7 @@ class Adafruit_GPS {
   void common_init(void);
 
   void sendCommand(const char *);
-  
+
   void pause(boolean b);
 
   boolean parseNMEA(char *response);
@@ -152,7 +152,7 @@ class Adafruit_GPS {
   uint8_t LOCUS_type, LOCUS_mode, LOCUS_config, LOCUS_interval, LOCUS_distance, LOCUS_speed, LOCUS_status, LOCUS_percent;
  private:
   boolean paused;
-  
+
   uint8_t parseResponse(char *response);
 #ifdef __AVR__
   #if ARDUINO >= 100


### PR DESCRIPTION
On non-AVR architectures (like the Arduino Zero or Feather M0), the given hardware serial object given the constructor would not have begin() called on it. This patch changes the behavior of this library's begin() function to call begin() on the hardware serial object regardless of architecture.

I also removed the trailing whitespace since it was bugging me. Cherry-pick the commit related to the begin function only if that's not a welcome change. :smile: 