### PR TITLE
Update Adafruit_GPS.cpp for HW Serial

### DIFF
--- a/Adafruit_GPS.cpp
+++ b/Adafruit_GPS.cpp
@@ -356,8 +356,9 @@ void Adafruit_GPS::begin(uint16_t baud)
   if(gpsSwSerial) 
     gpsSwSerial->begin(baud);
   else 
-    gpsHwSerial->begin(baud);
 #endif
+    gpsHwSerial->begin(baud);
+
 
   delay(10);
 }


### PR DESCRIPTION
Allows the GPS Ultimate logger work with HW serial port (on Ardiono 101 / Genuino 101).  Moved the #endif in the begin function to call gpsHwSerial->begin if no SwSerial.