### PR TITLE
Fail parser if no checksum

### DIFF
--- a/Adafruit_GPS.cpp
+++ b/Adafruit_GPS.cpp
@@ -46,6 +46,8 @@ boolean Adafruit_GPS::parse(char *nmea) {
       // bad checksum :(
       return false;
     }
+  } else {
+  	return false;
   }
   int32_t degree;
   long minutes;


### PR DESCRIPTION
As is: The parser will parse sentences even if a checksum is not found.
To be: Parser returns false if checksum not found.

**Describe the scope of your change.** 
a) If checksum is not found in sentence the parser now returns false immediately.
b) Parser will return true less often.
c) Parser will return false when checksum not found.
d) Junk sentences are less likely to be parsed.
e) Parser won't waste time parsing junk sentences.

**Describe any known limitations with your change.** 
Applies to all platforms.

**Please run any tests or examples that can exercise your modified code.** 
A/B testing conducted. Works well, particularly when line buffer is missing bytes but newlines are coming thru occasionally ( which enables "sentence ready for parsing" ).

Thank you.
