### PR TITLE
Changed parameter of Serial.begin

### DIFF
--- a/examples/echo/echo.pde
+++ b/examples/echo/echo.pde
@@ -52,9 +52,9 @@ void useInterrupt(boolean); // Func prototype keeps Arduino 0023 happy
 
 void setup()  
 {    
-  // connect at 115200 so we can read the GPS fast enuf and
-  // also spit it out
-  Serial.begin(115200);
+  // Would write garbage data if the baud rate for serial.begin 
+  // was not the same as the default baud rate.
+  Serial.begin(9600);
   Serial.println("Adafruit GPS library basic test!");
 
   // 9600 NMEA is the default baud rate for MTK - some use 4800


### PR DESCRIPTION
When the parameter of Serial.begin in the echo example was greater than the baud rate, the program would write invalid data to the serial monitor. When changed to be the same as the default baud rate (9600 in this case) it would work.
