### PR TITLE
also look for ublox specific headers while parsing

### DIFF
--- a/Adafruit_GPS.cpp
+++ b/Adafruit_GPS.cpp
@@ -51,7 +51,7 @@ boolean Adafruit_GPS::parse(char *nmea) {
   long minutes;
   char degreebuff[10];
   // look for a few common sentences
-  if (strstr(nmea, "$GPGGA")) {
+  if ((strstr(nmea, "$GPGGA")) || (strstr(nmea, "$GNGGA"))) {
     // found GGA
     char *p = nmea;
     // get time
@@ -154,7 +154,7 @@ boolean Adafruit_GPS::parse(char *nmea) {
     }
     return true;
   }
-  if (strstr(nmea, "$GPRMC")) {
+  if ((strstr(nmea, "$GPRMC")) || (strstr(nmea, "$GNRMC"))) {
    // found RMC
     char *p = nmea;
 


### PR DESCRIPTION
parse ublox sentences that start with $GNGGA and $GNRMC