### PR TITLE
Solving the Problem for Parsing Example with delay()

### DIFF
--- a/examples/leo_parsing/leo_parsing.ino
+++ b/examples/leo_parsing/leo_parsing.ino
@@ -8,7 +8,7 @@
 // Tested and works great with the Adafruit Ultimate GPS module
 // using MTK33x9 chipset
 //    ------> http://www.adafruit.com/products/746
-// Pick one up today at the Adafruit electronics shop 
+// Pick one up today at the Adafruit electronics shop
 // and help support open source hardware & software! -ada
 
 //This code is intended for use with Arduino Leonardo and other ATmega32U4-based Arduinos
@@ -39,9 +39,9 @@ HardwareSerial mySerial = Serial1;
 // Set to 'true' if you want to debug and listen to the raw GPS sentences
 #define GPSECHO  true
 
-void setup()  
+void setup()
 {
-    
+
   // connect at 115200 so we can read the GPS fast enough and echo without dropping chars
   // also spit it out
   Serial.begin(115200);
@@ -50,14 +50,14 @@ void setup()
 
   // 9600 NMEA is the default baud rate for Adafruit MTK GPS's- some use 4800
   GPS.begin(9600);
-  
+
   // uncomment this line to turn on RMC (recommended minimum) and GGA (fix data) including altitude
   GPS.sendCommand(PMTK_SET_NMEA_OUTPUT_RMCGGA);
   // uncomment this line to turn on only the "minimum recommended" data
   //GPS.sendCommand(PMTK_SET_NMEA_OUTPUT_RMCONLY);
   // For parsing data, we don't suggest using anything but either RMC only or RMC+GGA since
   // the parser doesn't care about other sentences at this time
-  
+
   // Set the update rate
   GPS.sendCommand(PMTK_SET_NMEA_UPDATE_1HZ);   // 1 Hz update rate
   // For the parsing code to work nicely and have time to sort thru the data, and
@@ -74,29 +74,21 @@ void setup()
 uint32_t timer = millis();
 void loop()                     // run over and over again
 {
-  char c = GPS.read();
-  // if you want to debug, this is a good time to do it!
-  if ((c) && (GPSECHO))
-    Serial.write(c); 
-  
-  // if a sentence is received, we can check the checksum, parse it...
-  if (GPS.newNMEAreceived()) {
+  do{
+    char c = GPS.read();
+    // if you want to debug, this is a good time to do it!
+    if ((c) && (GPSECHO))
+      Serial.write(c);
+  }while(!GPS.newNMEAreceived()); // if a sentence is received, we can check the checksum, parse it...
     // a tricky thing here is if we print the NMEA sentence, or data
-    // we end up not listening and catching other sentences! 
+    // we end up not listening and catching other sentences!
     // so be very wary if using OUTPUT_ALLDATA and trytng to print out data
     //Serial.println(GPS.lastNMEA());   // this also sets the newNMEAreceived() flag to false
-  
-    if (!GPS.parse(GPS.lastNMEA()))   // this also sets the newNMEAreceived() flag to false
-      return;  // we can fail to parse a sentence in which case we should just wait for another
-  }
 
-  // if millis() or timer wraps around, we'll just reset it
-  if (timer > millis())  timer = millis();
+  if (!GPS.parse(GPS.lastNMEA()))   // this also sets the newNMEAreceived() flag to false
+    return;  // we can fail to parse a sentence in which case we should just wait for another
 
-  // approximately every 2 seconds or so, print out the current stats
-  if (millis() - timer > 2000) { 
-    timer = millis(); // reset the timer
-    
+
     Serial.print("\nTime: ");
     Serial.print(GPS.hour, DEC); Serial.print(':');
     Serial.print(GPS.minute, DEC); Serial.print(':');
@@ -107,17 +99,16 @@ void loop()                     // run over and over again
     Serial.print(GPS.month, DEC); Serial.print("/20");
     Serial.println(GPS.year, DEC);
     Serial.print("Fix: "); Serial.print((int)GPS.fix);
-    Serial.print(" quality: "); Serial.println((int)GPS.fixquality); 
+    Serial.print(" quality: "); Serial.println((int)GPS.fixquality);
     if (GPS.fix) {
       Serial.print("Location: ");
       Serial.print(GPS.latitude, 4); Serial.print(GPS.lat);
-      Serial.print(", "); 
+      Serial.print(", ");
       Serial.print(GPS.longitude, 4); Serial.println(GPS.lon);
-      
+
       Serial.print("Speed (knots): "); Serial.println(GPS.speed);
       Serial.print("Angle: "); Serial.println(GPS.angle);
       Serial.print("Altitude: "); Serial.println(GPS.altitude);
       Serial.print("Satellites: "); Serial.println((int)GPS.satellites);
     }
-  }
 }

--- a/examples/leo_parsing/leo_parsing.ino
+++ b/examples/leo_parsing/leo_parsing.ino
@@ -74,17 +74,20 @@ void setup()
 uint32_t timer = millis();
 void loop()                     // run over and over again
 {
-  do{
+  while(true){
     char c = GPS.read();
     // if you want to debug, this is a good time to do it!
     if ((c) && (GPSECHO))
       Serial.write(c);
-  }while(!GPS.newNMEAreceived()); // if a sentence is received, we can check the checksum, parse it...
-    // a tricky thing here is if we print the NMEA sentence, or data
-    // we end up not listening and catching other sentences!
-    // so be very wary if using OUTPUT_ALLDATA and trytng to print out data
-    //Serial.println(GPS.lastNMEA());   // this also sets the newNMEAreceived() flag to false
 
+    // if a sentence is received, we can check the checksum, parse it...  
+    if(GPS.newNMEAreceived())
+      break;
+  }
+
+  // a tricky thing here is if we print the NMEA sentence, or data
+  // we end up not listening and catching other sentences!
+  // so be very wary if using OUTPUT_ALLDATA and trytng to print out data
   if (!GPS.parse(GPS.lastNMEA()))   // this also sets the newNMEAreceived() flag to false
     return;  // we can fail to parse a sentence in which case we should just wait for another
 


### PR DESCRIPTION
There was a problem when sketch contains delay() function, wrong values were being returned from the sketch because that serial communication was being delayed. 

When we use delay() in loop(), there was being a delay time between each chars which were received from serial communication because each chars were received one by one in each loop(). To prevent this, all of chars should be received from serial communication using one loop, so there wasn't any delay time between chars. 

This solution is not optimal, this should be solved in library side.