### PR TITLE
negative value for S/W for {latitude,longitude}_fixed

### DIFF
--- a/Adafruit_GPS.cpp
+++ b/Adafruit_GPS.cpp
@@ -86,11 +86,17 @@ boolean Adafruit_GPS::parse(char *nmea) {
     p = strchr(p, ',')+1;
     if (',' != *p)
     {
-      if (p[0] == 'S') latitudeDegrees *= -1.0;
-      if (p[0] == 'N') lat = 'N';
-      else if (p[0] == 'S') lat = 'S';
-      else if (p[0] == ',') lat = 0;
-      else return false;
+      if (p[0] == 'S') {
+        lat = 'S';
+        latitudeDegrees *= -1.0;
+        latitude_fixed *= -1.0;
+      } else if (p[0] == 'N') {
+        lat = 'N';
+      } else if (p[0] == ',') {
+        lat = 0;
+      } else {
+        return false;
+      }
     }
     
     // parse out longitude
@@ -115,11 +121,17 @@ boolean Adafruit_GPS::parse(char *nmea) {
     p = strchr(p, ',')+1;
     if (',' != *p)
     {
-      if (p[0] == 'W') longitudeDegrees *= -1.0;
-      if (p[0] == 'W') lon = 'W';
-      else if (p[0] == 'E') lon = 'E';
-      else if (p[0] == ',') lon = 0;
-      else return false;
+      if (p[0] == 'W') {
+        lon = 'W';
+        longitudeDegrees *= -1.0;
+        longitude_fixed *= -1.0;
+      } else if (p[0] == 'E') {
+        lon = 'E';
+      } else if (p[0] == ',') {
+        lon = 0;
+      } else {
+        return false;
+      }
     }
     
     p = strchr(p, ',')+1;
@@ -155,7 +167,7 @@ boolean Adafruit_GPS::parse(char *nmea) {
     return true;
   }
   if (strstr(nmea, "$GPRMC")) {
-   // found RMC
+    // found RMC
     char *p = nmea;
 
     // get time
@@ -199,11 +211,17 @@ boolean Adafruit_GPS::parse(char *nmea) {
     p = strchr(p, ',')+1;
     if (',' != *p)
     {
-      if (p[0] == 'S') latitudeDegrees *= -1.0;
-      if (p[0] == 'N') lat = 'N';
-      else if (p[0] == 'S') lat = 'S';
-      else if (p[0] == ',') lat = 0;
-      else return false;
+      if (p[0] == 'S') {
+        lat = 'S';
+        latitudeDegrees *= -1.0;
+        latitude_fixed *= -1.0;
+      } else if (p[0] == 'N') {
+        lat = 'N';
+      } else if (p[0] == ',') {
+        lat = 0;
+      } else {
+        return false;
+      }
     }
     
     // parse out longitude
@@ -228,11 +246,17 @@ boolean Adafruit_GPS::parse(char *nmea) {
     p = strchr(p, ',')+1;
     if (',' != *p)
     {
-      if (p[0] == 'W') longitudeDegrees *= -1.0;
-      if (p[0] == 'W') lon = 'W';
-      else if (p[0] == 'E') lon = 'E';
-      else if (p[0] == ',') lon = 0;
-      else return false;
+      if (p[0] == 'W') {
+        lon = 'W';
+        longitudeDegrees *= -1.0;
+        longitude_fixed *= -1.0;
+      } else if (p[0] == 'E') {
+        lon = 'E';
+      } else if (p[0] == ',') {
+        lon = 0;
+      } else {
+        return false;
+      }
     }
     // speed
     p = strchr(p, ',')+1;


### PR DESCRIPTION
I noticed that latitude_fixed and longitude_fixed added by https://github.com/adafruit/Adafruit_GPS/pull/13 were missing their sign. Was this intentional, @koehn ?

If someone is depending on this not having a sign, this PR will break them, but the lack of sign seems like an oversight to me. I need the sign for my code so if there is a better way to get it on {latitude,longitude}_fixed, please let me know.

I also thinking of adding some more comments that explain latitude vs lat vs latitudeDegrees vs latitude_fixed.