### PR TITLE
Fix read() so NMEA sentences are properly CR-LF terminated

### DIFF
--- a/Adafruit_GPS.h
+++ b/Adafruit_GPS.h
@@ -148,7 +148,7 @@ class Adafruit_GPS {
   uint8_t fixquality;       ///< Fix quality (0, 1, 2 = Invalid, GPS, DGPS)
   uint8_t satellites;       ///< Number of satellites in use
 
-  boolean waitForSentence(const char *wait, uint8_t max = MAXWAITSENTENCE);
+  boolean waitForSentence(const char *wait, uint8_t max = MAXWAITSENTENCE, boolean usingInterrupts = false);
   boolean LOCUS_StartLogger(void);
   boolean LOCUS_StopLogger(void);
   boolean LOCUS_ReadStatus(void);


### PR DESCRIPTION
**read()**
Fixed read() so that the LF that terminates a NMEA sentence is placed at the end of the NMEA sentence it terminates (as part of a CR-LF pair), rather than at the beginning of the _next_ NMEA sentence.  With this change, NMEA sentences returned by the library will start with the '$' character and end with a CR-LF pair per the NMEA specification.  Please be aware that user code depending on the prior incorrect behavior may stop working.  Previously only the first NMEA sentence returned by the library started with a '$' character; subsequent sentences started with a LF character.  And previously all NMEA sentences were terminated with a lone CR rather than a CR-LF pair.

**parse()**
As a result of the change to read(), changes were necessary to the checksum code in parse() because the relevant indices into the NMEA buffer shifted one byte towards the front of the buffer.  The code was also changed to invoke strlen() once, rather than 3 times and in the for-loop condition clause (which invoked it once for each character of the NMEA sentence!)

In addition, rather than using strstr to check for the talker/type of message (e.g., GPRMC), parse() invokes a new utility routine strStartsWith.  (See below.)

**waitForSentence()**
The previous version of waitForSentence() assumed that the library user was not using interrupts to read from the GPS chip. The routine was modified to add a third parameter, usingInterrupts, which indicates whether or not the caller has configured an ISR to read from the GPS chip.  If usingInterrupts is false (which is the default value for usingInterrupts) the routine behaves as before.  If usingInterrupts is true, waitForSentence does not invoke read() in its loop, but just checks newNMEAReceived().  In addition, the routine was modified to use strStartsWith() rather than strstr() and to eliminate making a local copy of the start of the nmea message.  _(Upon further reflection you may still want to make a local copy of the start of the NMEA sentence because if sentence are coming in fast enough, read() might change the buffer out from under waitForSentence?  However, perhaps a comment indicating why the local copy is being made would be helpful.)_

**strStartsWith()**
Add a small utility routine that is passed a string and a prefix and returns true if the string starts with the prefix.  I think this is clearer that using strstr (and possibly more efficient) because in the cases where strstr was being called, you really wanted to know if the NMEA sentence started with the particular talker/message type.


