### PR TITLE
Add 115200 bps and parse $GPGLL

### DIFF
--- a/Adafruit_GPS.cpp
+++ b/Adafruit_GPS.cpp
@@ -61,7 +61,7 @@ boolean Adafruit_GPS::parse(char *nmea) {
     sum += parseHex(*(ast+2));
 
     // check checksum
-    for (char *p = strchr(nmea,'$')+1; p < ast; p++) {
+    for (char *p = nmea+2; p < ast; p++) {
       sum ^= *p;
     }
     if (sum != 0) {
@@ -414,7 +414,7 @@ char Adafruit_GPS::read(void) {
     recvdflag = true;
   }
 
-  if(c != '\n' && c != '\r') currentline[lineidx++] = c;
+  currentline[lineidx++] = c;
   if (lineidx >= MAXLINELENGTH)
     lineidx = MAXLINELENGTH-1;
 

--- a/Adafruit_GPS.cpp
+++ b/Adafruit_GPS.cpp
@@ -280,6 +280,89 @@ boolean Adafruit_GPS::parse(char *nmea) {
     // we dont parse the remaining, yet!
     return true;
   }
+  if (strstr(nmea, "$GPGLL")) {
+   // found GLL
+    char *p = nmea;
+
+    // parse out latitude
+    p = strchr(p, ',')+1;
+    if (',' != *p)
+    {
+      strncpy(degreebuff, p, 2);
+      p += 2;
+      degreebuff[2] = '\0';
+      long degree = atol(degreebuff) * 10000000;
+      strncpy(degreebuff, p, 2); // minutes
+      p += 3; // skip decimal point
+      strncpy(degreebuff + 2, p, 4);
+      degreebuff[6] = '\0';
+      long minutes = 50 * atol(degreebuff) / 3;
+      latitude_fixed = degree + minutes;
+      latitude = degree / 100000 + minutes * 0.000006F;
+      latitudeDegrees = (latitude-100*int(latitude/100))/60.0;
+      latitudeDegrees += int(latitude/100);
+    }
+
+    p = strchr(p, ',')+1;
+    if (',' != *p)
+    {
+      if (p[0] == 'S') latitudeDegrees *= -1.0;
+      if (p[0] == 'N') lat = 'N';
+      else if (p[0] == 'S') lat = 'S';
+      else if (p[0] == ',') lat = 0;
+      else return false;
+    }
+
+    // parse out longitude
+    p = strchr(p, ',')+1;
+    if (',' != *p)
+    {
+      strncpy(degreebuff, p, 3);
+      p += 3;
+      degreebuff[3] = '\0';
+      degree = atol(degreebuff) * 10000000;
+      strncpy(degreebuff, p, 2); // minutes
+      p += 3; // skip decimal point
+      strncpy(degreebuff + 2, p, 4);
+      degreebuff[6] = '\0';
+      minutes = 50 * atol(degreebuff) / 3;
+      longitude_fixed = degree + minutes;
+      longitude = degree / 100000 + minutes * 0.000006F;
+      longitudeDegrees = (longitude-100*int(longitude/100))/60.0;
+      longitudeDegrees += int(longitude/100);
+    }
+
+    p = strchr(p, ',')+1;
+    if (',' != *p)
+    {
+      if (p[0] == 'W') longitudeDegrees *= -1.0;
+      if (p[0] == 'W') lon = 'W';
+      else if (p[0] == 'E') lon = 'E';
+      else if (p[0] == ',') lon = 0;
+      else return false;
+    }
+
+    // get time
+    p = strchr(p, ',')+1;
+    float timef = atof(p);
+    uint32_t time = timef;
+    hour = time / 10000;
+    minute = (time % 10000) / 100;
+    seconds = (time % 100);
+
+    milliseconds = fmod(timef, 1.0) * 1000;
+
+    p = strchr(p, ',')+1;
+    // Serial.println(p);
+    if (p[0] == 'A')
+      fix = true;
+    else if (p[0] == 'V')
+      fix = false;
+    else
+      return false;
+
+    return true;
+  }
 
   return false;
 }

--- a/Adafruit_GPS.cpp
+++ b/Adafruit_GPS.cpp
@@ -285,7 +285,7 @@ boolean Adafruit_GPS::parse(char *nmea) {
     // we dont parse the remaining, yet!
     return true;
   }
-  if (strstr(nmea, "$GPGLL")) {
+  if (strStartsWith(nmea, "$GPGLL")) {
    // found GLL
     char *p = nmea;
 

--- a/Adafruit_GPS.cpp
+++ b/Adafruit_GPS.cpp
@@ -55,13 +55,14 @@ boolean Adafruit_GPS::parse(char *nmea) {
   // do checksum check
 
   // first look if we even have one
-  if (nmea[strlen(nmea)-4] == '*') {
-    uint16_t sum = parseHex(nmea[strlen(nmea)-3]) * 16;
-    sum += parseHex(nmea[strlen(nmea)-2]);
+  char *ast = strchr(nmea,'*');
+  if (ast != NULL) {
+    uint16_t sum = parseHex(*(ast+1)) * 16;
+    sum += parseHex(*(ast+2));
 
     // check checksum
-    for (uint8_t i=2; i < (strlen(nmea)-4); i++) {
-      sum ^= nmea[i];
+    for (char *p = nmea+2; p < ast; p++) {
+      sum ^= *p;
     }
     if (sum != 0) {
       // bad checksum :(

--- a/Adafruit_GPS.cpp
+++ b/Adafruit_GPS.cpp
@@ -55,14 +55,13 @@ boolean Adafruit_GPS::parse(char *nmea) {
   // do checksum check
 
   // first look if we even have one
-  char *ast = strchr(nmea,'*');
-  if (ast != NULL) {
-    uint16_t sum = parseHex(*(ast+1)) * 16;
-    sum += parseHex(*(ast+2));
+  if (nmea[strlen(nmea)-4] == '*') {
+    uint16_t sum = parseHex(nmea[strlen(nmea)-3]) * 16;
+    sum += parseHex(nmea[strlen(nmea)-2]);
 
     // check checksum
-    for (char *p = nmea+2; p < ast; p++) {
-      sum ^= *p;
+    for (uint8_t i=2; i < (strlen(nmea)-4); i++) {
+      sum ^= nmea[i];
     }
     if (sum != 0) {
       // bad checksum :(

--- a/Adafruit_GPS.cpp
+++ b/Adafruit_GPS.cpp
@@ -61,7 +61,7 @@ boolean Adafruit_GPS::parse(char *nmea) {
     sum += parseHex(*(ast+2));
 
     // check checksum
-    for (char *p = nmea+2; p < ast; p++) {
+    for (char *p = strchr(nmea,'$')+1; p < ast; p++) {
       sum ^= *p;
     }
     if (sum != 0) {
@@ -414,7 +414,7 @@ char Adafruit_GPS::read(void) {
     recvdflag = true;
   }
 
-  currentline[lineidx++] = c;
+  if(c != '\n' && c != '\r') currentline[lineidx++] = c;
   if (lineidx >= MAXLINELENGTH)
     lineidx = MAXLINELENGTH-1;
 

--- a/Adafruit_GPS.h
+++ b/Adafruit_GPS.h
@@ -51,8 +51,9 @@
 #define PMTK_API_SET_FIX_CTL_5HZ  "$PMTK300,200,0,0,0,0*2F"               ///< 5 Hz
 // Can't fix position faster than 5 times a second!
 
-#define PMTK_SET_BAUD_57600 "$PMTK251,57600*2C" ///< 57600 bps
-#define PMTK_SET_BAUD_9600 "$PMTK251,9600*17"   ///<  9600 bps
+#define PMTK_SET_BAUD_115200 "$PMTK251,115200*1F"  ///< 115200 bps
+#define PMTK_SET_BAUD_57600  "$PMTK251,57600*2C"   ///<  57600 bps
+#define PMTK_SET_BAUD_9600   "$PMTK251,9600*17"    ///<   9600 bps
 
 #define PMTK_SET_NMEA_OUTPUT_RMCONLY "$PMTK314,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0*29"  ///< turn on only the second sentence (GPRMC)
 #define PMTK_SET_NMEA_OUTPUT_RMCGGA "$PMTK314,0,1,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0*28"   ///< turn on GPRMC and GGA


### PR DESCRIPTION
Scope: Define a new string constant to set the GPS module to 115200 bps. Copy and rearrange the code from the $GPRMC section of parse() to support the $GPGLL sentence provided by some GPS units (e.g. Standard Horizon Chartplotter). $GPGLL is just latitude, longitude, time, and fix in that order.

Limits: Should not affect any existing code or platforms

Works between the $ and the *, so not affected by parsing changes around the CRLF issues.

The parse() code contains a lot of repetition that could be broken out to separate functions that might be parseAngle(), etc. If this pull goes through, I might tackle that next.