### PR TITLE
Parse sentences with GNSS identifiers

### DIFF
--- a/Adafruit_GPS.cpp
+++ b/Adafruit_GPS.cpp
@@ -79,7 +79,7 @@ boolean Adafruit_GPS::parse(char *nmea) {
   // look for a few common sentences
   char *p = nmea;
   
-  if (strStartsWith(nmea, "$GPGGA")) {
+  if (strStartsWith(nmea, "$GPGGA") || strStartsWith(nmea, "$GNGGA")) {
     // found GGA
     // get time
     p = strchr(p, ',')+1;
@@ -135,7 +135,7 @@ boolean Adafruit_GPS::parse(char *nmea) {
     return true;
   }
   
-  if (strStartsWith(nmea, "$GPRMC")) {
+  if (strStartsWith(nmea, "$GPRMC") || strStartsWith(nmea, "$GNRMC")) {
     // found RMC
     // get time
     p = strchr(p, ',')+1;
@@ -183,7 +183,7 @@ boolean Adafruit_GPS::parse(char *nmea) {
     return true;
   }
   
-  if (strStartsWith(nmea, "$GPGLL")) {
+  if (strStartsWith(nmea, "$GPGLL") || strStartsWith(nmea, "$GNGLL")) {
     // found GLL
     // parse out latitude
     p = strchr(p, ',')+1;


### PR DESCRIPTION
GPS modules utilizing [GNSS](https://en.wikipedia.org/wiki/GNSS_applications) will emit different talker identifiers than those using [GPS](https://en.wikipedia.org/wiki/Global_Positioning_System). See [NMEA 0183 Talker Identifier Mnemonics](https://www.nmea.org/Assets/20190303%20nmea%200183%20talker%20identifier%20mnemonics.pdf) for more details.

`Adafruit_GPS::parse` was modified to search for sentences with the `GN` identifier in the address field in addition to the `GP` identifier. No other modifications were necessary.

This has been tested on hardware using a [Sierra Wireless XA1110](https://www.sierrawireless.com/products-and-solutions/embedded-solutions/products/xa1110/) on a MKR Zero.

This PR supercedes  #66 .
