### PR TITLE
Change GPS time alignment

### DIFF
--- a/Adafruit_GPS.cpp
+++ b/Adafruit_GPS.cpp
@@ -103,7 +103,7 @@ boolean Adafruit_GPS::parse(char *nmea) {
       fixquality = atoi(p);
       if(fixquality > 0){
         fix = true;
-        lastFix = recvdTime;
+        lastFix = sentTime;
       } else
         fix = false;
     }
@@ -178,7 +178,7 @@ boolean Adafruit_GPS::parse(char *nmea) {
       day = fulldate / 10000;
       month = (fulldate % 10000) / 100;
       year = (fulldate % 100);
-      lastDate = recvdTime;
+      lastDate = sentTime;
     }
     return true;
   }
@@ -227,7 +227,7 @@ void Adafruit_GPS::parseTime(char *p) {
 
     p = strchr(p, '.')+1;
     milliseconds = atoi(p);
-    lastTime = recvdTime;
+    lastTime = sentTime;
 }
 
 /**************************************************************************/
@@ -343,7 +343,7 @@ boolean Adafruit_GPS::parseLonDir(char *p) {
 boolean Adafruit_GPS::parseFix(char *p) {
     if (p[0] == 'A'){
       fix = true;
-      lastFix = recvdTime;
+      lastFix = sentTime;
       }
     else if (p[0] == 'V')
       fix = false;
@@ -392,6 +392,8 @@ float Adafruit_GPS::secondsSinceDate() {
 */
 /**************************************************************************/
 char Adafruit_GPS::read(void) {
+  static uint32_t firstChar = 0;   // first character received in current sentence
+  uint32_t tStart = millis();      // as close as we can get to time char was sent
   char c = 0;
 
   if (paused) return c;
@@ -434,8 +436,12 @@ char Adafruit_GPS::read(void) {
     lineidx = 0;
     recvdflag = true;
     recvdTime = millis();   // time we got the end of the string
+    sentTime = firstChar;
+    firstChar = 0;          // there are no characters yet
+    return c;               // wait until next character to set time
   }
 
+  if(firstChar == 0) firstChar = tStart;
   return c;
 }
 

--- a/Adafruit_GPS.h
+++ b/Adafruit_GPS.h
@@ -187,6 +187,7 @@ class Adafruit_GPS {
   uint32_t lastTime = 2000000000L;    // millis() when last time received
   uint32_t lastDate = 2000000000L;    // millis() when last date received
   uint32_t recvdTime = 2000000000L;   // millis() when last full sentence received
+  uint32_t sentTime = 2000000000L;   // millis() when first character of last full sentence received
   boolean paused;
 
   uint8_t parseResponse(char *response);


### PR DESCRIPTION
Detect time first character of NMEA sentence received and treat that as corresponding to GPS timestamp in the sentence. Still some latency, but less than using the end of the receipt.

This has no effect unless you are using the secondsSinceXXX() functions added recently. It makes them more accurate by a small fraction of a second. There is still some latency and that latency will vary with each sentence received, depending on how often you call read(), just as it did before the change.