### PR TITLE
Improve NMEA sentence checking

### DIFF
--- a/Adafruit_GPS.cpp
+++ b/Adafruit_GPS.cpp
@@ -958,3 +958,20 @@ boolean Adafruit_GPS::wakeup(void) {
       return false;  // Returns false if not in standby mode, nothing to wakeup
   }
 }
+
+/**************************************************************************/
+/*!
+    @brief Checks whether a string starts with a specified prefix
+    @param str Pointer to a string
+    @param prefix Pointer to the prefix
+    @return True if str starts with prefix, false otherwise
+*/
+/**************************************************************************/
+static boolean strStartsWith(const char* str, const char* prefix)
+{
+  while (*prefix) {
+    if (*prefix++ != *str++)
+      return false;
+  }
+  return true;
+}

--- a/Adafruit_GPS.h
+++ b/Adafruit_GPS.h
@@ -31,8 +31,8 @@
 #define GPS_MAX_I2C_TRANSFER 32  ///< The max number of bytes we'll try to read at once
 #define GPS_MAX_SPI_TRANSFER 100  ///< The max number of bytes we'll try to read at once
 #define MAXLINELENGTH 120 ///< how long are max NMEA lines to parse?
-#define NMEA_MAX_SENTENCE_ID  20    // maximum length of a sentence ID name, including terminating 0
-#define NMEA_MAX_SOURCE_ID     3    // maximum length of a source ID name, including terminating 0
+#define NMEA_MAX_SENTENCE_ID  20    ///< maximum length of a sentence ID name, including terminating 0
+#define NMEA_MAX_SOURCE_ID     3    ///< maximum length of a source ID name, including terminating 0
 
 
 #include "Arduino.h"
@@ -104,14 +104,14 @@
 /**************************************************************************/
 
 typedef enum {
-    NMEA_BAD                  =  0,   // passed none of the checks
-    NMEA_HAS_DOLLAR           =  1,   // has a dollar sign in the first position
-    NMEA_HAS_CHECKSUM         =  2,   // has a valid checksum at the end
-    NMEA_HAS_NAME             =  4,   // there is a token after the $ followed by a comma
-    NMEA_HAS_SOURCE           = 10,   // has a recognized source ID
-    NMEA_HAS_SENTENCE         = 20,   // has a recognized sentence ID
-    NMEA_HAS_SENTENCE_P       = 40    // has a recognized parseable sentence ID
-} nmea_check_t;
+    NMEA_BAD                  =  0,   ///< passed none of the checks
+    NMEA_HAS_DOLLAR           =  1,   ///< has a dollar sign in the first position
+    NMEA_HAS_CHECKSUM         =  2,   ///< has a valid checksum at the end
+    NMEA_HAS_NAME             =  4,   ///< there is a token after the $ followed by a comma
+    NMEA_HAS_SOURCE           = 10,   ///< has a recognized source ID
+    NMEA_HAS_SENTENCE         = 20,   ///< has a recognized sentence ID
+    NMEA_HAS_SENTENCE_P       = 40    ///< has a recognized parseable sentence ID
+} nmea_check_t;                       ///< resulting code from running check()
 
 /**************************************************************************/
 /*!
@@ -152,11 +152,11 @@ class Adafruit_GPS : public Print{
   boolean wakeup(void);
   boolean standby(void);
 
-  int thisCheck = 0;                              // the results of the check on the current sentence
-  char thisSource[NMEA_MAX_SOURCE_ID] = {0};      // the first two letters of the current sentence, e.g. WI, GP
-  char thisSentence[NMEA_MAX_SENTENCE_ID] = {0};  // the next three letters of the current sentence, e.g. GLL, RMC
-  char lastSource[NMEA_MAX_SOURCE_ID] = {0};      // same for last correctly parsed sentence
-  char lastSentence[NMEA_MAX_SENTENCE_ID] = {0};
+  int thisCheck = 0;                                ///< the results of the check on the current sentence
+  char thisSource[NMEA_MAX_SOURCE_ID] = {0};        ///< the first two letters of the current sentence, e.g. WI, GP
+  char thisSentence[NMEA_MAX_SENTENCE_ID] = {0};    ///< the next three letters of the current sentence, e.g. GLL, RMC
+  char lastSource[NMEA_MAX_SOURCE_ID] = {0};        ///< the results of the check on the most recent successfully parsed sentence
+  char lastSentence[NMEA_MAX_SENTENCE_ID] = {0};    ///< the next three letters of the most recent successfully parsed sentence, e.g. GLL, RMC
 
   uint8_t hour;                                     ///< GMT hours
   uint8_t minute;                                   ///< GMT minutes
@@ -218,18 +218,18 @@ class Adafruit_GPS : public Print{
   boolean parseLonDir(char *);
   boolean parseFix(char *);
   // used by check() for validity tests, room for future expansion
-  const char *sources[5] =          {"II",  "WI",  "GP",  "GN",  "ZZZ"};
-  const char *sentences_parsed[5] = {"GGA", "GLL", "GSA", "RMC", "ZZZ"};
-  const char *sentences_known[1] =  {"ZZZ"};
+  const char *sources[5] =          {"II",  "WI",  "GP",  "GN",  "ZZZ"};  ///< valid source ids
+  const char *sentences_parsed[5] = {"GGA", "GLL", "GSA", "RMC", "ZZZ"};  ///< parseable sentence ids
+  const char *sentences_known[1] =  {"ZZZ"};        ///< known, but not parseable sentence ids
   
   // Make all of these times far in the past by setting them near the middle of the
   // millis() range. Timing assumes that sentences are parsed promptly.
-  uint32_t lastUpdate = 2000000000L;  // millis() when last full sentence successfully parsed
-  uint32_t lastFix = 2000000000L;     // millis() when last fix received
-  uint32_t lastTime = 2000000000L;    // millis() when last time received
-  uint32_t lastDate = 2000000000L;    // millis() when last date received
-  uint32_t recvdTime = 2000000000L;   // millis() when last full sentence received
-  uint32_t sentTime = 2000000000L;    // millis() when first character of last full sentence received
+  uint32_t lastUpdate = 2000000000L;  ///< millis() when last full sentence successfully parsed
+  uint32_t lastFix = 2000000000L;     ///< millis() when last fix received
+  uint32_t lastTime = 2000000000L;    ///< millis() when last time received
+  uint32_t lastDate = 2000000000L;    ///< millis() when last date received
+  uint32_t recvdTime = 2000000000L;   ///< millis() when last full sentence received
+  uint32_t sentTime = 2000000000L;    ///< millis() when first character of last full sentence received
   boolean paused;
 
   uint8_t parseResponse(char *response);

--- a/Adafruit_GPS.h
+++ b/Adafruit_GPS.h
@@ -103,6 +103,7 @@
 #define MAXWAITSENTENCE 10   ///< how long to wait when we're looking for a response
 /**************************************************************************/
 
+/// type for resulting code from running check()
 typedef enum {
     NMEA_BAD                  =  0,   ///< passed none of the checks
     NMEA_HAS_DOLLAR           =  1,   ///< has a dollar sign in the first position
@@ -111,7 +112,7 @@ typedef enum {
     NMEA_HAS_SOURCE           = 10,   ///< has a recognized source ID
     NMEA_HAS_SENTENCE         = 20,   ///< has a recognized sentence ID
     NMEA_HAS_SENTENCE_P       = 40    ///< has a recognized parseable sentence ID
-} nmea_check_t;                       ///< resulting code from running check()
+} nmea_check_t;                       
 
 /**************************************************************************/
 /*!


### PR DESCRIPTION
Scope: Add check(), addChecksum(), tokenOnList(), and supporting variables. Modify parse() to use check() and test only on sentence name, e.g. GGA rather than $GPGGA. Uses strcmp() to eliminate the custom strStartsWith() -- tokenOnList() does a more detailed check for what a string starts with. addChecksum() will allow users to build their own sentences with valid checksums, possibly reducing the need for additional $PMTK definitions in the .h file.

Repairs indenting on GSA parsing and replaces 12 repeated p = strchr(p, ',')+1; with a loop. (Note that the diff parsing breaks here, so it may be hard to read.)

Addresses https://github.com/adafruit/Adafruit_GPS/issues/96.

Provides functionality to move towards options discussed in https://github.com/adafruit/Adafruit_GPS/issues/106.

Limitations: Adds a modest overhead with some new variables. Still compiles with enough memory on an UNO.
