### PR TITLE
Fix a few warnings

### DIFF
--- a/examples/GPS_SoftwareSerial_LOCUS_Erase/GPS_SoftwareSerial_LOCUS_Erase.ino
+++ b/examples/GPS_SoftwareSerial_LOCUS_Erase/GPS_SoftwareSerial_LOCUS_Erase.ino
@@ -27,7 +27,7 @@ Adafruit_GPS GPS(&mySerial);
 // this keeps track of whether we're using the interrupt
 // off by default!
 #ifndef ESP8266 // Sadly not on ESP8266
-boolean usingInterrupt = false;
+bool usingInterrupt = false;
 #endif
 
 void setup()
@@ -84,7 +84,7 @@ ISR(TIMER0_COMPA_vect) {
   }
 }
 
-void useInterrupt(boolean v) {
+void useInterrupt(bool v) {
   if (v) {
     // Timer0 is already used for millis() - we'll just interrupt somewhere
     // in the middle and call the "Compare A" function above

--- a/examples/GPS_SoftwareSerial_LOCUS_Start/GPS_SoftwareSerial_LOCUS_Start.ino
+++ b/examples/GPS_SoftwareSerial_LOCUS_Start/GPS_SoftwareSerial_LOCUS_Start.ino
@@ -29,7 +29,7 @@ Adafruit_GPS GPS(&mySerial);
 // this keeps track of whether we're using the interrupt
 // off by default!
 #ifndef ESP8266 // Sadly not on ESP8266
-boolean usingInterrupt = false;
+bool usingInterrupt = false;
 #endif
 
 void setup()
@@ -89,7 +89,7 @@ ISR(TIMER0_COMPA_vect) {
   }
 }
 
-void useInterrupt(boolean v) {
+void useInterrupt(bool v) {
   if (v) {
     // Timer0 is already used for millis() - we'll just interrupt somewhere
     // in the middle and call the "Compare A" function above

--- a/examples/GPS_SoftwareSerial_LOCUS_Status/GPS_SoftwareSerial_LOCUS_Status.ino
+++ b/examples/GPS_SoftwareSerial_LOCUS_Status/GPS_SoftwareSerial_LOCUS_Status.ino
@@ -29,7 +29,7 @@ Adafruit_GPS GPS(&mySerial);
 // this keeps track of whether we're using the interrupt
 // off by default!
 #ifndef ESP8266 // Sadly not on ESP8266
-boolean usingInterrupt = false;
+bool usingInterrupt = false;
 #endif
 
 void setup()
@@ -127,7 +127,7 @@ ISR(TIMER0_COMPA_vect) {
 #endif
 }
 
-void useInterrupt(boolean v) {
+void useInterrupt(bool v) {
   if (v) {
     // Timer0 is already used for millis() - we'll just interrupt somewhere
     // in the middle and call the "Compare A" function above

--- a/examples/shield_sdlog/shield_sdlog.ino
+++ b/examples/shield_sdlog/shield_sdlog.ino
@@ -29,7 +29,7 @@ Adafruit_GPS GPS(&mySerial);
 // this keeps track of whether we're using the interrupt
 // off by default!
 #ifndef ESP8266 // Sadly not on ESP8266
-boolean usingInterrupt = false;
+bool usingInterrupt = false;
 #endif
 
 // Set the pins used
@@ -152,7 +152,7 @@ ISR(TIMER0_COMPA_vect) {
   #endif
 }
 
-void useInterrupt(boolean v) {
+void useInterrupt(bool v) {
   if (v) {
     // Timer0 is already used for millis() - we'll just interrupt somewhere
     // in the middle and call the "Compare A" function above

--- a/src/Adafruit_GPS.cpp
+++ b/src/Adafruit_GPS.cpp
@@ -205,8 +205,6 @@ void Adafruit_GPS::parseTime(char *p) {
 */
 /**************************************************************************/
 void Adafruit_GPS::parseLat(char *p) {
-  int32_t degree;
-  long minutes;
   char degreebuff[10];
   if (!isEmpty(p)) {
     strncpy(degreebuff, p, 2);

--- a/src/Adafruit_GPS.cpp
+++ b/src/Adafruit_GPS.cpp
@@ -218,7 +218,7 @@ void Adafruit_GPS::parseLat(char *p) {
     long minutes = 50 * atol(degreebuff) / 3;
     latitude_fixed = degree + minutes;
     latitude = degree / 100000 + minutes * 0.000006F;
-    latitudeDegrees = (latitude - 100 * int(latitude / 100)) / 60.0;
+    latitudeDegrees = (latitude - 100 * int(latitude / 100)) / 60.0f;
     latitudeDegrees += int(latitude / 100);
   }
 }
@@ -233,7 +233,7 @@ void Adafruit_GPS::parseLat(char *p) {
 bool Adafruit_GPS::parseLatDir(char *p) {
   if (p[0] == 'S') {
     lat = 'S';
-    latitudeDegrees *= -1.0;
+    latitudeDegrees *= -1.0f;
     latitude_fixed *= -1;
   } else if (p[0] == 'N') {
     lat = 'N';
@@ -267,7 +267,7 @@ void Adafruit_GPS::parseLon(char *p) {
     minutes = 50 * atol(degreebuff) / 3;
     longitude_fixed = degree + minutes;
     longitude = degree / 100000 + minutes * 0.000006F;
-    longitudeDegrees = (longitude - 100 * int(longitude / 100)) / 60.0;
+    longitudeDegrees = (longitude - 100 * int(longitude / 100)) / 60.0f;
     longitudeDegrees += int(longitude / 100);
   }
 }
@@ -283,7 +283,7 @@ bool Adafruit_GPS::parseLonDir(char *p) {
   if (!isEmpty(p)) {
     if (p[0] == 'W') {
       lon = 'W';
-      longitudeDegrees *= -1.0;
+      longitudeDegrees *= -1.0f;
       longitude_fixed *= -1;
     } else if (p[0] == 'E') {
       lon = 'E';

--- a/src/Adafruit_GPS.cpp
+++ b/src/Adafruit_GPS.cpp
@@ -30,7 +30,7 @@
 
 #include <Adafruit_GPS.h>
 
-static boolean strStartsWith(const char *str, const char *prefix);
+static bool strStartsWith(const char *str, const char *prefix);
 
 /**************************************************************************/
 /*!
@@ -41,7 +41,7 @@ static boolean strStartsWith(const char *str, const char *prefix);
     @return True if well formed, false if it has problems
 */
 /**************************************************************************/
-boolean Adafruit_GPS::check(char *nmea) {
+bool Adafruit_GPS::check(char *nmea) {
   thisCheck = 0; // new check
   if (*nmea != '$')
     return false; // doesn't start with $
@@ -232,7 +232,7 @@ void Adafruit_GPS::parseLat(char *p) {
     @return True if we parsed it, false if it has invalid data
 */
 /**************************************************************************/
-boolean Adafruit_GPS::parseLatDir(char *p) {
+bool Adafruit_GPS::parseLatDir(char *p) {
   if (p[0] == 'S') {
     lat = 'S';
     latitudeDegrees *= -1.0;
@@ -281,7 +281,7 @@ void Adafruit_GPS::parseLon(char *p) {
     @return True if we parsed it, false if it has invalid data
 */
 /**************************************************************************/
-boolean Adafruit_GPS::parseLonDir(char *p) {
+bool Adafruit_GPS::parseLonDir(char *p) {
   if (!isEmpty(p)) {
     if (p[0] == 'W') {
       lon = 'W';
@@ -305,7 +305,7 @@ boolean Adafruit_GPS::parseLonDir(char *p) {
     @return True if we parsed it, false if it has invalid data
 */
 /**************************************************************************/
-boolean Adafruit_GPS::parseFix(char *p) {
+bool Adafruit_GPS::parseFix(char *p) {
   if (p[0] == 'A') {
     fix = true;
     lastFix = sentTime;
@@ -601,7 +601,7 @@ void Adafruit_GPS::common_init(void) {
   hour = minute = seconds = year = month = day = fixquality = fixquality_3d =
       satellites = 0;  // uint8_t
   lat = lon = mag = 0; // char
-  fix = false;         // boolean
+  fix = false;         // bool
   milliseconds = 0;    // uint16_t
   latitude = longitude = geoidheight = altitude = speed = angle = magvariation =
       HDOP = VDOP = PDOP = 0.0; // nmea_float_t
@@ -661,7 +661,7 @@ void Adafruit_GPS::sendCommand(const char *str) { println(str); }
     @return True if received, false if not
 */
 /**************************************************************************/
-boolean Adafruit_GPS::newNMEAreceived(void) { return recvdflag; }
+bool Adafruit_GPS::newNMEAreceived(void) { return recvdflag; }
 
 /**************************************************************************/
 /*!
@@ -669,7 +669,7 @@ boolean Adafruit_GPS::newNMEAreceived(void) { return recvdflag; }
     @param p True = pause, false = unpause
 */
 /**************************************************************************/
-void Adafruit_GPS::pause(boolean p) { paused = p; }
+void Adafruit_GPS::pause(bool p) { paused = p; }
 
 /**************************************************************************/
 /*!
@@ -714,8 +714,8 @@ uint8_t Adafruit_GPS::parseHex(char c) {
     @return True if we got what we wanted, false otherwise
 */
 /**************************************************************************/
-boolean Adafruit_GPS::waitForSentence(const char *wait4me, uint8_t max,
-                                      boolean usingInterrupts) {
+bool Adafruit_GPS::waitForSentence(const char *wait4me, uint8_t max,
+                                   bool usingInterrupts) {
   uint8_t i = 0;
   while (i < max) {
     if (!usingInterrupts)
@@ -739,7 +739,7 @@ boolean Adafruit_GPS::waitForSentence(const char *wait4me, uint8_t max,
     @return True on success, false if it failed
 */
 /**************************************************************************/
-boolean Adafruit_GPS::LOCUS_StartLogger(void) {
+bool Adafruit_GPS::LOCUS_StartLogger(void) {
   sendCommand(PMTK_LOCUS_STARTLOG);
   recvdflag = false;
   return waitForSentence(PMTK_LOCUS_STARTSTOPACK);
@@ -751,7 +751,7 @@ boolean Adafruit_GPS::LOCUS_StartLogger(void) {
     @return True on success, false if it failed
 */
 /**************************************************************************/
-boolean Adafruit_GPS::LOCUS_StopLogger(void) {
+bool Adafruit_GPS::LOCUS_StopLogger(void) {
   sendCommand(PMTK_LOCUS_STOPLOG);
   recvdflag = false;
   return waitForSentence(PMTK_LOCUS_STARTSTOPACK);
@@ -763,7 +763,7 @@ boolean Adafruit_GPS::LOCUS_StopLogger(void) {
     @return True if we read the data, false if there was no response
 */
 /**************************************************************************/
-boolean Adafruit_GPS::LOCUS_ReadStatus(void) {
+bool Adafruit_GPS::LOCUS_ReadStatus(void) {
   sendCommand(PMTK_LOCUS_QUERY_STATUS);
 
   if (!waitForSentence("$PMTKLOG"))
@@ -815,7 +815,7 @@ boolean Adafruit_GPS::LOCUS_ReadStatus(void) {
     @return False if already in standby, true if it entered standby
 */
 /**************************************************************************/
-boolean Adafruit_GPS::standby(void) {
+bool Adafruit_GPS::standby(void) {
   if (inStandbyMode) {
     return false; // Returns false if already in standby mode, so that you do
                   // not wake it up by sending commands to GPS
@@ -834,7 +834,7 @@ boolean Adafruit_GPS::standby(void) {
     @return True if woken up, false if not in standby or failed to wake
 */
 /**************************************************************************/
-boolean Adafruit_GPS::wakeup(void) {
+bool Adafruit_GPS::wakeup(void) {
   if (inStandbyMode) {
     inStandbyMode = false;
     sendCommand(""); // send byte to wake it up
@@ -852,7 +852,7 @@ boolean Adafruit_GPS::wakeup(void) {
     @return True if str starts with prefix, false otherwise
 */
 /**************************************************************************/
-static boolean strStartsWith(const char *str, const char *prefix) {
+static bool strStartsWith(const char *str, const char *prefix) {
   while (*prefix) {
     if (*prefix++ != *str++)
       return false;

--- a/src/Adafruit_GPS.h
+++ b/src/Adafruit_GPS.h
@@ -85,12 +85,12 @@ public:
   Adafruit_GPS(SPIClass *theSPI, int8_t cspin); // Constructor when using SPI
 
   char *lastNMEA(void);
-  boolean newNMEAreceived();
+  bool newNMEAreceived();
   void common_init(void);
 
   void sendCommand(const char *);
 
-  void pause(boolean b);
+  void pause(bool b);
 
   uint8_t parseHex(char c);
 
@@ -98,16 +98,16 @@ public:
   size_t write(uint8_t);
   size_t available(void);
 
-  boolean check(char *nmea);
-  boolean parse(char *);
+  bool check(char *nmea);
+  bool parse(char *);
   void addChecksum(char *buff);
   nmea_float_t secondsSinceFix();
   nmea_float_t secondsSinceTime();
   nmea_float_t secondsSinceDate();
   void resetSentTime();
 
-  boolean wakeup(void);
-  boolean standby(void);
+  bool wakeup(void);
+  bool standby(void);
 
   int thisCheck = 0; ///< the results of the check on the current sentence
   char thisSource[NMEA_MAX_SOURCE_ID] = {
@@ -157,16 +157,16 @@ public:
   char lat = 'X';    ///< N/S
   char lon = 'X';    ///< E/W
   char mag = 'X';    ///< Magnetic variation direction
-  boolean fix;       ///< Have a fix?
+  bool fix;          ///< Have a fix?
   uint8_t fixquality;    ///< Fix quality (0, 1, 2 = Invalid, GPS, DGPS)
   uint8_t fixquality_3d; ///< 3D fix quality (1, 3, 3 = Nofix, 2D fix, 3D fix)
   uint8_t satellites;    ///< Number of satellites in use
 
-  boolean waitForSentence(const char *wait, uint8_t max = MAXWAITSENTENCE,
-                          boolean usingInterrupts = false);
-  boolean LOCUS_StartLogger(void);
-  boolean LOCUS_StopLogger(void);
-  boolean LOCUS_ReadStatus(void);
+  bool waitForSentence(const char *wait, uint8_t max = MAXWAITSENTENCE,
+                       bool usingInterrupts = false);
+  bool LOCUS_StartLogger(void);
+  bool LOCUS_StopLogger(void);
+  bool LOCUS_ReadStatus(void);
 
   uint16_t LOCUS_serial;  ///< Log serial number
   uint16_t LOCUS_records; ///< Log number of data record
@@ -197,10 +197,10 @@ private:
   bool isEmpty(char *pStart);
   void parseTime(char *);
   void parseLat(char *);
-  boolean parseLatDir(char *);
+  bool parseLatDir(char *);
   void parseLon(char *);
-  boolean parseLonDir(char *);
-  boolean parseFix(char *);
+  bool parseLonDir(char *);
+  bool parseFix(char *);
   // used by check() for validity tests, room for future expansion
   const char *sources[5] = {"II", "WI", "GP", "GN",
                             "ZZZ"}; ///< valid source ids
@@ -220,7 +220,7 @@ private:
       2000000000L; ///< millis() when last full sentence received
   uint32_t sentTime = 2000000000L; ///< millis() when first character of last
                                    ///< full sentence received
-  boolean paused;
+  bool paused;
 
   uint8_t parseResponse(char *response);
 #if (defined(__AVR__) || defined(ESP8266)) && defined(USE_SW_SERIAL)
@@ -242,11 +242,11 @@ private:
   volatile char line1[MAXLINELENGTH]; ///< We double buffer: read one line in
                                       ///< and leave one for the main program
   volatile char line2[MAXLINELENGTH]; ///< Second buffer
-  volatile uint8_t lineidx = 0;   ///< our index into filling the current line
-  volatile char *currentline;     ///< Pointer to current line buffer
-  volatile char *lastline;        ///< Pointer to previous line buffer
-  volatile boolean recvdflag;     ///< Received flag
-  volatile boolean inStandbyMode; ///< In standby flag
+  volatile uint8_t lineidx = 0; ///< our index into filling the current line
+  volatile char *currentline;   ///< Pointer to current line buffer
+  volatile char *lastline;      ///< Pointer to previous line buffer
+  volatile bool recvdflag;      ///< Received flag
+  volatile bool inStandbyMode;  ///< In standby flag
 };
 /**************************************************************************/
 

--- a/src/NMEA_build.cpp
+++ b/src/NMEA_build.cpp
@@ -108,8 +108,8 @@ char *Adafruit_GPS::build(char *nmea, const char *thisSource,
     // 15) Checksum
     sprintf(p, "%09.2f,%09.4f,%c,%010.4f,%c,%d,%02d,%f,%f,M,%f,M,,",
             hour * 10000L + minute * 100L + seconds + milliseconds / 1000.,
-            latitude, lat, longitude, lon, fixquality, satellites, HDOP,
-            altitude, geoidheight);
+            (double)latitude, lat, (double)longitude, lon, fixquality,
+            satellites, (double)HDOP, (double)altitude, (double)geoidheight);
 
   } else if (!strcmp(thisSentence,
                      "GLL")) { //********************************************GLL
@@ -124,7 +124,8 @@ char *Adafruit_GPS::build(char *nmea, const char *thisSource,
     // 5) Time (UTC)
     // 6) Status A - Data Valid, V - Data Invalid
     // 7) Checksum
-    sprintf(p, "%09.4f,%c,%010.4f,%c,%09.2f,A", latitude, lat, longitude, lon,
+    sprintf(p, "%09.4f,%c,%010.4f,%c,%09.2f,A", (double)latitude, lat,
+            (double)longitude, lon,
             hour * 10000L + minute * 100L + seconds + milliseconds / 1000.);
 
   } else if (!strcmp(thisSentence,
@@ -166,8 +167,9 @@ char *Adafruit_GPS::build(char *nmea, const char *thisSource,
     // 12) Checksum
     sprintf(p, "%09.2f,A,%09.4f,%c,%010.4f,%c,%f,%f,%06d,%f,%c",
             hour * 10000L + minute * 100L + seconds + milliseconds / 1000.,
-            latitude, lat, longitude, lon, speed, angle,
-            day * 10000 + month * 100 + year, magvariation, mag);
+            (double)latitude, lat, (double)longitude, lon, (double)speed,
+            (double)angle, day * 10000 + month * 100 + year,
+            (double)magvariation, mag);
 
   } else if (!strcmp(thisSentence,
                      "TXT")) { //********************************************TXT

--- a/src/NMEA_parse.cpp
+++ b/src/NMEA_parse.cpp
@@ -38,7 +38,7 @@
    data
 */
 /**************************************************************************/
-boolean Adafruit_GPS::parse(char *nmea) {
+bool Adafruit_GPS::parse(char *nmea) {
   // do checksum check
   if (!check(nmea))
     return false;


### PR DESCRIPTION
This fixes the following warnings:

- Replace uses of `boolean` with `bool`.  The STM32 Arduino core has deprecated this type (stm32duino/Arduino_Core_STM32@48b6e7d89cb0f11b119c0c8134e10149d900472c) resulting in compiler warnings.  Arduino has considered doing the same (arduino/Arduino#4673) and [the reference now recommends the standard type](https://www.arduino.cc/reference/en/language/variables/data-types/boolean/).
- Remove some unused variables.
- Remove some automatic promotions from `float` to `double`.
  - This causes warnings with `-Wdouble-promotion`, which is desirable on many embedded platforms since they have only a single precision FPU or no FPU at all.  softfloat is slow and takes up additional code space.
  - Unfortunately doubles are unavoidable when passing floats as arguments to the `printf` family of functions, so I just added explicit casts there to silence the warning.  This isn't ideal, but the `build` function that uses these calls should be optimized out if you don't use it.
