### PR TITLE
Correct handling of millis() rollover

### DIFF
--- a/examples/GPS_HardwareSerial_LOCUS_Status/GPS_HardwareSerial_LOCUS_Status.ino
+++ b/examples/GPS_HardwareSerial_LOCUS_Status/GPS_HardwareSerial_LOCUS_Status.ino
@@ -58,7 +58,7 @@ void setup()
     Serial.println(" no response :(");
 }
 
-uint32_t updateTime = 1000;
+uint32_t timer = 0;
 
 void loop()                     // run over and over again
 {
@@ -67,9 +67,9 @@ void loop()                     // run over and over again
   if ((c) && (GPSECHO))
     Serial.write(c);
 
-  if (millis() > updateTime)
+  if (millis() - timer > 1000)
   {
-    updateTime = millis() + 1000;
+    timer = millis();
     if (GPS.LOCUS_ReadStatus()) {
        Serial.print("\n\nLog #");
        Serial.print(GPS.LOCUS_serial, DEC);
@@ -98,5 +98,5 @@ void loop()                     // run over and over again
       Serial.print((int)GPS.LOCUS_percent); Serial.print("% Used ");
 
     }//if (GPS.LOCUS_ReadStatus())
-  }//if (millis() > updateTime)
+  }//if (millis() - timer > 1000)
 }//loop

--- a/examples/GPS_HardwareSerial_Parsing/GPS_HardwareSerial_Parsing.ino
+++ b/examples/GPS_HardwareSerial_Parsing/GPS_HardwareSerial_Parsing.ino
@@ -76,8 +76,6 @@ void loop() // run over and over again
     if (!GPS.parse(GPS.lastNMEA())) // this also sets the newNMEAreceived() flag to false
       return; // we can fail to parse a sentence in which case we should just wait for another
   }
-  // if millis() or timer wraps around, we'll just reset it
-  if (timer > millis()) timer = millis();
 
   // approximately every 2 seconds or so, print out the current stats
   if (millis() - timer > 2000) {

--- a/examples/GPS_HardwareSerial_Timing/GPS_HardwareSerial_Timing.ino
+++ b/examples/GPS_HardwareSerial_Timing/GPS_HardwareSerial_Timing.ino
@@ -101,9 +101,6 @@ void loop() // run over and over again
       return; // we can fail to parse a sentence in which case we should just
               // wait for another
   }
-  // if millis() or timer wraps around, we'll just reset it
-  if (timer > millis())
-    timer = millis();
 
   // approximately every 2 seconds or so, random intervals, print out the
   // current stats

--- a/examples/GPS_I2C_Parsing/GPS_I2C_Parsing.ino
+++ b/examples/GPS_I2C_Parsing/GPS_I2C_Parsing.ino
@@ -64,8 +64,6 @@ void loop() // run over and over again
     if (!GPS.parse(GPS.lastNMEA())) // this also sets the newNMEAreceived() flag to false
       return; // we can fail to parse a sentence in which case we should just wait for another
   }
-  // if millis() or timer wraps around, we'll just reset it
-  if (timer > millis()) timer = millis();
 
   // approximately every 2 seconds or so, print out the current stats
   if (millis() - timer > 2000) {

--- a/examples/GPS_SoftwareSerial_LOCUS_Status/GPS_SoftwareSerial_LOCUS_Status.ino
+++ b/examples/GPS_SoftwareSerial_LOCUS_Status/GPS_SoftwareSerial_LOCUS_Status.ino
@@ -68,7 +68,7 @@ void setup()
   }
 }
 
-uint32_t updateTime = 1000;
+uint32_t timer = 0;
 
 void loop()                     // run over and over again
 {
@@ -77,9 +77,9 @@ void loop()                     // run over and over again
   if ((c) && (GPSECHO))
     Serial.write(c);
 
-  if (millis() > updateTime)
+  if (millis() - timer > 1000)
   {
-    updateTime = millis() + 1000;
+    timer = millis();
     if (GPS.LOCUS_ReadStatus()) {
        Serial.print("\n\nLog #");
        Serial.print(GPS.LOCUS_serial, DEC);
@@ -108,7 +108,7 @@ void loop()                     // run over and over again
       Serial.print((int)GPS.LOCUS_percent); Serial.print("% Used ");
 
     }//if (GPS.LOCUS_ReadStatus())
-  }//if (millis() > updateTime)
+  }//if (millis() - timer > 1000)
 }//loop
 
 

--- a/examples/GPS_SoftwareSerial_Parsing/GPS_SoftwareSerial_Parsing.ino
+++ b/examples/GPS_SoftwareSerial_Parsing/GPS_SoftwareSerial_Parsing.ino
@@ -78,9 +78,6 @@ void loop()                     // run over and over again
       return;  // we can fail to parse a sentence in which case we should just wait for another
   }
 
-  // if millis() or timer wraps around, we'll just reset it
-  if (timer > millis())  timer = millis();
-
   // approximately every 2 seconds or so, print out the current stats
   if (millis() - timer > 2000) {
     timer = millis(); // reset the timer

--- a/src/Adafruit_GPS.cpp
+++ b/src/Adafruit_GPS.cpp
@@ -637,8 +637,7 @@ bool Adafruit_GPS::wakeup(void) {
 
 /**************************************************************************/
 /*!
-    @brief Time in seconds since the last position fix was obtained. Will
-    fail by rolling over to zero after one millis() cycle, about 6-1/2 weeks.
+    @brief Time in seconds since the last position fix was obtained.
     @return nmea_float_t value in seconds since last fix.
 */
 /**************************************************************************/
@@ -648,8 +647,7 @@ nmea_float_t Adafruit_GPS::secondsSinceFix() {
 
 /**************************************************************************/
 /*!
-    @brief Time in seconds since the last GPS time was obtained. Will fail
-    by rolling over to zero after one millis() cycle, about 6-1/2 weeks.
+    @brief Time in seconds since the last GPS time was obtained.
     @return nmea_float_t value in seconds since last GPS time.
 */
 /**************************************************************************/
@@ -659,8 +657,7 @@ nmea_float_t Adafruit_GPS::secondsSinceTime() {
 
 /**************************************************************************/
 /*!
-    @brief Time in seconds since the last GPS date was obtained. Will fail
-    by rolling over to zero after one millis() cycle, about 6-1/2 weeks.
+    @brief Time in seconds since the last GPS date was obtained.
     @return nmea_float_t value in seconds since last GPS date.
 */
 /**************************************************************************/

--- a/src/Adafruit_GPS.cpp
+++ b/src/Adafruit_GPS.cpp
@@ -637,7 +637,10 @@ bool Adafruit_GPS::wakeup(void) {
 
 /**************************************************************************/
 /*!
-    @brief Time in seconds since the last position fix was obtained.
+    @brief Time in seconds since the last position fix was obtained. The
+    time returned is limited to 2^32 milliseconds, which is about 49.7 days.
+    It will wrap around to zero if no position fix is received
+    for this long.
     @return nmea_float_t value in seconds since last fix.
 */
 /**************************************************************************/
@@ -647,7 +650,9 @@ nmea_float_t Adafruit_GPS::secondsSinceFix() {
 
 /**************************************************************************/
 /*!
-    @brief Time in seconds since the last GPS time was obtained.
+    @brief Time in seconds since the last GPS time was obtained. The time
+    returned is limited to 2^32 milliseconds, which is about 49.7 days. It
+    will wrap around to zero if no GPS time is received for this long.
     @return nmea_float_t value in seconds since last GPS time.
 */
 /**************************************************************************/
@@ -657,7 +662,9 @@ nmea_float_t Adafruit_GPS::secondsSinceTime() {
 
 /**************************************************************************/
 /*!
-    @brief Time in seconds since the last GPS date was obtained.
+    @brief Time in seconds since the last GPS date was obtained. The time
+    returned is limited to 2^32 milliseconds, which is about 49.7 days. It
+    will wrap around to zero if no GPS date is received for this long.
     @return nmea_float_t value in seconds since last GPS date.
 */
 /**************************************************************************/

--- a/src/NMEA_data.cpp
+++ b/src/NMEA_data.cpp
@@ -60,7 +60,7 @@ void Adafruit_GPS::newDataValue(nmea_index_t idx, nmea_float_t v) {
   // weighting factor for smoothing depends on delta t / tau
   nmea_float_t w =
       min((nmea_float_t)1.0,
-          ((nmea_float_t)millis() - val[idx].lastUpdate) / val[idx].response);
+          (nmea_float_t)(millis() - val[idx].lastUpdate) / val[idx].response);
   // default smoothing
   val[idx].smoothed = (1.0 - w) * val[idx].smoothed + w * v;
   // special smoothing for some angle types


### PR DESCRIPTION
This pull requests addresses multiple issues that stem from a misunderstanding or mishandling of the `millis()` rollover.

Specifically, the example sketches GPS\_{Hardware,Software}Serial\_LOCUS\_Status.ino contained the test

```c++
if (millis() > updateTime)
```

which will not work as expected when `millis()` is close to a rollover event and `updateTime` is just past the event. On the other hand, several other examples use the form

```c++
if (millis() - timer > 2000)
```

which, owing to the fact that the subtraction is done modulo (ULONG\_MAX+1), [is immune to rollover events][stackexchange]. The test is, however, preceded by a misguided attempt to manage the rollover:

```c++
// if millis() or timer wraps around, we'll just reset it
if (timer > millis()) timer = millis();
```

Those lines do more harm than good, as they create a glitch in the timing that would not exist without them.

In the same vein, the methods `secondsSince{Fix,Time,Date}()` are rollover-safe and their documentation should not state that they will fail on a rollover.

Finally, in NMEA\_data.cpp, the expression

```c++
((nmea_float_t)millis() - val[idx].lastUpdate)
```

fails on a rollover because the subtraction is performed on a floating point data type, which does not obey the rules of modular arithmetics. The correct behavior is achieved if the subtraction is done _before_ the cast to a floating type.

[stackexchange]: https://arduino.stackexchange.com/questions/12587/how-can-i-handle-the-millis-rollover