### PR TITLE
Bugfix for parseCoord

### DIFF
--- a/src/NMEA_parse.cpp
+++ b/src/NMEA_parse.cpp
@@ -682,7 +682,7 @@ bool Adafruit_GPS::parseCoord(char *pStart, nmea_float_t *angleDegrees,
   char *p = pStart;
   if (!isEmpty(p)) {
     // get the number in DDDMM.mmmm format and break into components
-    char degreebuff[10];
+    char degreebuff[10] = {0}; // Ensure string is terminated after strncpy
     char *e = strchr(p, '.');
     if (e == NULL || e - p > 6)
       return false;                // no decimal point in range


### PR DESCRIPTION
Fixes a problem in parseCoord (#120) where an uninitialized array could result in an unterminated string and errors parsing lat/lon.

Tested on:
- Metro (Uno)
- Mega2560
- Feather M0 Express
- Feather M4 Express
- Feather Huzzah ESP8266
- Feather Huzzah ESP32