### PR TITLE
Fix issue with millisecond parsing.

### DIFF
--- a/src/NMEA_parse.cpp
+++ b/src/NMEA_parse.cpp
@@ -785,7 +785,7 @@ bool Adafruit_GPS::parseTime(char *p) {
     char *dec = strchr(p, '.');
     char *comstar = min(strchr(p, ','), strchr(p, '*'));
     if (dec != NULL && comstar != NULL && dec < comstar)
-      milliseconds = atof(p) * 1000;
+      milliseconds = atof(dec) * 1000;
     else
       milliseconds = 0;
     lastTime = sentTime;


### PR DESCRIPTION
(Edit: after writing the below info, I saw that there's an open issue for this: https://github.com/adafruit/Adafruit_GPS/issues/127)

By calling atof() on p, we're converting the entire time string  (101520.123 for 10:15:20am and 123 milliseconds) to a float, then multiplying by 1000 to get ms. This results in a value that overflows and exhibits all sorts of strange behavior as seconds and minutes turn over. It's clearly not what was intended. From the if statement wrapping the conversion, it is clear that the author intended to make the atof() conversion on the dec pointer, instead. Making this change fixes the parsing so that Adafruit_GPS' milliseconds property correctly matches the value in the NMEA sentence.

The scope of the change is about as small as it could possible. There are no limitations or trade-offs. It's a straight-up bug fix.

To see the bug (and test the fix):

```
  if (GPS->newNMEAreceived()) {
    GPS->parse(GPS->lastNMEA());
    Serial.print(GPS->milliseconds);
    Serial.print(" ");
    Serial.println(GPS->lastNMEA());
  }

```
Note that, before the fix, milliseconds will not match the NMEA sentence. Over time, you'll also see it overflow uint16_t, but also have discontinuities (jumping from ~28000 to ~1000 is the last one I saw, but you'll see a discontinuity roughly twice per minute; once when the seconds go from 59 to 0 and another when uint16_t overflows.)