### PR TITLE
131 add parse for antenna stats

### DIFF
--- a/examples/GPS_HardwareSerial_Parsing/GPS_HardwareSerial_Parsing.ino
+++ b/examples/GPS_HardwareSerial_Parsing/GPS_HardwareSerial_Parsing.ino
@@ -108,6 +108,7 @@ void loop() // run over and over again
       Serial.print("Angle: "); Serial.println(GPS.angle);
       Serial.print("Altitude: "); Serial.println(GPS.altitude);
       Serial.print("Satellites: "); Serial.println((int)GPS.satellites);
+      Serial.print("Antenna status: "); Serial.println((int)GPS.antenna);
     }
   }
 }

--- a/examples/GPS_SoftwareSerial_Parsing/GPS_SoftwareSerial_Parsing.ino
+++ b/examples/GPS_SoftwareSerial_Parsing/GPS_SoftwareSerial_Parsing.ino
@@ -111,6 +111,7 @@ void loop()                     // run over and over again
       Serial.print("Angle: "); Serial.println(GPS.angle);
       Serial.print("Altitude: "); Serial.println(GPS.altitude);
       Serial.print("Satellites: "); Serial.println((int)GPS.satellites);
+      Serial.print("Antenna status: "); Serial.println((int)GPS.antenna);
     }
   }
 }

--- a/src/Adafruit_GPS.cpp
+++ b/src/Adafruit_GPS.cpp
@@ -255,7 +255,7 @@ void Adafruit_GPS::common_init(void) {
   lastline = line2;
 
   hour = minute = seconds = year = month = day = fixquality = fixquality_3d =
-      satellites = 0;  // uint8_t
+      satellites = antenna = 0;  // uint8_t
   lat = lon = mag = 0; // char
   fix = false;         // bool
   milliseconds = 0;    // uint16_t

--- a/src/Adafruit_GPS.h
+++ b/src/Adafruit_GPS.h
@@ -197,6 +197,7 @@ public:
   uint8_t fixquality;    ///< Fix quality (0, 1, 2 = Invalid, GPS, DGPS)
   uint8_t fixquality_3d; ///< 3D fix quality (1, 3, 3 = Nofix, 2D fix, 3D fix)
   uint8_t satellites;    ///< Number of satellites in use
+  uint8_t antenna;       ///< Antenna that is used (from PGTOP)
 
   uint16_t LOCUS_serial;  ///< Log serial number
   uint16_t LOCUS_records; ///< Log number of data record
@@ -245,24 +246,25 @@ private:
   char *parseStr(char *buff, char *p, int n);
   bool parseTime(char *);
   bool parseFix(char *);
+  bool parseAntenna(char *);
   bool isEmpty(char *pStart);
 
   // used by check() for validity tests, room for future expansion
-  const char *sources[6] = {"II", "WI", "GP",
+  const char *sources[7] = {"II", "WI", "GP", "PG",
                             "GN", "P",  "ZZZ"}; ///< valid source ids
 #ifdef NMEA_EXTENSIONS
   const char
-      *sentences_parsed[20] =
+      *sentences_parsed[21] =
           {
               "GGA", "GLL", "GSA", "RMC", "DBT", "HDM", "HDT",
-              "MDA", "MTW", "MWV", "RMB", "TXT", "VHW", "VLW",
-              "VPW", "VWR", "WCV", "XTE", "ZZZ"}; ///< parseable sentence ids
+              "MDA", "MTW", "MWV", "RMB", "TOP", "TXT", "VHW",
+              "VLW", "VPW", "VWR", "WCV", "XTE", "ZZZ"}; ///< parseable sentence ids
   const char *sentences_known[15] = {
       "APB", "DPT", "GSV", "HDG", "MWD", "ROT",
       "RPM", "RSA", "VDR", "VTG", "ZDA", "ZZZ"}; ///< known, but not parseable
 #else // make the lists short to save memory
-  const char *sentences_parsed[5] = {"GGA", "GLL", "GSA", "RMC",
-                                     "ZZZ"}; ///< parseable sentence ids
+  const char *sentences_parsed[6] = {"GGA", "GLL", "GSA", "RMC",
+                                     "TOP", "ZZZ"}; ///< parseable sentence ids
   const char *sentences_known[4] = {"DBT", "HDM", "HDT",
                                     "ZZZ"}; ///< known, but not parseable
 #endif

--- a/src/NMEA_parse.cpp
+++ b/src/NMEA_parse.cpp
@@ -173,7 +173,17 @@ bool Adafruit_GPS::parse(char *nmea) {
     if (!isEmpty(p))
       VDOP = atof(p); // last before checksum
 
+  } else if (!strcmp(thisSentence, "TOP")) { //*****************************TOP
+    // See: https://learn.adafruit.com/adafruit-ultimate-gps-featherwing/antenna-options
+    // There is an output sentence that will tell you the status of the 
+    // antenna. $PGTOP,11,x where x is the status number. If x is 3 that means 
+    // it is using the external antenna. If x is 2 it's using the internal 
+    // antenna and if x is 1 there was an antenna short or problem.
+    p = strchr(p, ',') + 1;
+    parseAntenna(p);
   }
+
+
 #ifdef NMEA_EXTENSIONS // Sentences not required for basic GPS functionality
   else if (!strcmp(thisSentence, "APB")) { //*******************************APB
     // from Actisense NGW-1 from SH CP150C
@@ -809,6 +819,30 @@ bool Adafruit_GPS::parseFix(char *p) {
     } else if (p[0] == 'V')
       fix = false;
     else
+      return false;
+    return true;
+  }
+  return false;
+}
+
+/**************************************************************************/
+/*!
+    @brief Parse a part of an NMEA string for antenna that is used
+    @param p Pointer to the location of the token in the NMEA string
+    @return 3: external antenna  
+            2: internal antenna  
+            1: there was an antenna short or problem
+*/
+/**************************************************************************/
+bool Adafruit_GPS::parseAntenna(char *p) {
+  if (!isEmpty(p)) {
+    if (p[0] == '3') {
+      antenna = 3;
+    } else if (p[0] == '2') {
+      antenna = 2;
+    } else if (p[0] == '1') {
+      antenna = 1;
+    } else
       return false;
     return true;
   }


### PR DESCRIPTION
Implementation for feature request #131 

Add parsing for the antenna status as is described here:

> https://learn.adafruit.com/adafruit-ultimate-gps-featherwing/antenna-options
> There is an output sentence that will tell you the status of the antenna. $PGTOP,11,x where x is the status number. If x is 3 that means it is using the external antenna. If x is 2 it's using the internal antenna and if x is 1 there was an antenna short or problem.

Tested with Huzzah32 and Ultimate GPS featherwing

