### PR TITLE
Add #define to disable SW Serial

### DIFF
--- a/src/Adafruit_GPS.h
+++ b/src/Adafruit_GPS.h
@@ -41,8 +41,8 @@
 
 #if (defined(__AVR__) || defined(ESP8266)) && !defined(NO_SW_SERIAL)
 #define USE_SW_SERIAL ///< insert line `#define NO_SW_SERIAL` before this header
-                      ///< if you don't want to include software serial in the library
-#endif
+                      ///< if you don't want to include software serial in the
+#endif                ///< library
 #define GPS_DEFAULT_I2C_ADDR                                                   \
   0x10 ///< The default address for I2C transport of GPS data
 #define GPS_MAX_I2C_TRANSFER                                                   \

--- a/src/Adafruit_GPS.h
+++ b/src/Adafruit_GPS.h
@@ -39,6 +39,10 @@
 #endif
 #endif
 
+#if (defined(__AVR__) || defined(ESP8266)) && !defined(NO_SW_SERIAL)
+#define USE_SW_SERIAL ///< insert line `#define NO_SW_SERIAL` before this header
+                      ///< if you don't want to include software serial in the library
+#endif
 #define GPS_DEFAULT_I2C_ADDR                                                   \
   0x10 ///< The default address for I2C transport of GPS data
 #define GPS_MAX_I2C_TRANSFER                                                   \
@@ -52,7 +56,7 @@
   3 ///< maximum length of a source ID name, including terminating 0
 
 #include "Arduino.h"
-#if (defined(__AVR__) || defined(ESP8266)) && !defined(NO_SW_SERIAL)
+#ifdef USE_SW_SERIAL
 #include <SoftwareSerial.h>
 #endif
 #include <Adafruit_PMTK.h>
@@ -81,7 +85,7 @@ public:
   // Adafruit_GPS.cpp
   bool begin(uint32_t baud_or_i2caddr);
 
-#if (defined(__AVR__) || defined(ESP8266)) && !defined(NO_SW_SERIAL)
+#ifdef USE_SW_SERIAL
   Adafruit_GPS(SoftwareSerial *ser); // Constructor when using SoftwareSerial
 #endif
   Adafruit_GPS(HardwareSerial *ser); // Constructor when using HardwareSerial
@@ -279,7 +283,7 @@ private:
   bool paused;
 
   uint8_t parseResponse(char *response);
-#if (defined(__AVR__) || defined(ESP8266)) && !defined(NO_SW_SERIAL)
+#ifdef USE_SW_SERIAL
   SoftwareSerial *gpsSwSerial;
 #endif
   bool noComms = false;

--- a/src/Adafruit_GPS.h
+++ b/src/Adafruit_GPS.h
@@ -39,8 +39,6 @@
 #endif
 #endif
 
-#define USE_SW_SERIAL ///< comment this out if you don't want to include
-                      ///< software serial in the library
 #define GPS_DEFAULT_I2C_ADDR                                                   \
   0x10 ///< The default address for I2C transport of GPS data
 #define GPS_MAX_I2C_TRANSFER                                                   \
@@ -54,7 +52,7 @@
   3 ///< maximum length of a source ID name, including terminating 0
 
 #include "Arduino.h"
-#if (defined(__AVR__) || defined(ESP8266)) && defined(USE_SW_SERIAL)
+#if (defined(__AVR__) || defined(ESP8266)) && !defined(NO_SW_SERIAL)
 #include <SoftwareSerial.h>
 #endif
 #include <Adafruit_PMTK.h>
@@ -83,7 +81,7 @@ public:
   // Adafruit_GPS.cpp
   bool begin(uint32_t baud_or_i2caddr);
 
-#if (defined(__AVR__) || defined(ESP8266)) && defined(USE_SW_SERIAL)
+#if (defined(__AVR__) || defined(ESP8266)) && !defined(NO_SW_SERIAL)
   Adafruit_GPS(SoftwareSerial *ser); // Constructor when using SoftwareSerial
 #endif
   Adafruit_GPS(HardwareSerial *ser); // Constructor when using HardwareSerial
@@ -281,7 +279,7 @@ private:
   bool paused;
 
   uint8_t parseResponse(char *response);
-#if (defined(__AVR__) || defined(ESP8266)) && defined(USE_SW_SERIAL)
+#if (defined(__AVR__) || defined(ESP8266)) && !defined(NO_SW_SERIAL)
   SoftwareSerial *gpsSwSerial;
 #endif
   bool noComms = false;


### PR DESCRIPTION
I'm using this library with a board that does not support SoftwareSerial, and the library failed to compile.

I found that a line could be commented out in the library to disable SoftwareSerial, but I feel like it's a bad idea to have to edit the source code of a library in order to use it.

I'm proposing a new `#define` statement to disable the use of SoftwareSerial when needed so that users don't have to dig in the source code.

I tested the new code on a AVR128DA48 Curiosity Nano running DxCore, uploaded using Platformio.