### PR TITLE
Fix include guard in `NMEA_data.h`

### DIFF
--- a/src/NMEA_data.h
+++ b/src/NMEA_data.h
@@ -4,7 +4,7 @@
 */
 /**************************************************************************/
 #ifndef _NMEA_DATA_H
-#define _NMEA__DATA_H
+#define _NMEA_DATA_H
 #include "Arduino.h"
 
 #define NMEA_MAX_WP_ID                                                         \


### PR DESCRIPTION
This PR removes a superfluous underscore to fix `NMEA_data.h`s include guard.
