### PR TITLE
Add trip distance.  Simplify parseCoords().  parse RMC only if valid fix.

### DIFF
--- a/src/Adafruit_GPS.cpp
+++ b/src/Adafruit_GPS.cpp
@@ -443,6 +443,18 @@ bool Adafruit_GPS::waitForSentence(const char *wait4me, uint8_t max,
 
 /**************************************************************************/
 /*!
+    @brief Set the tolerance for accepting distance travelled is real
+    @brief movement not just drift
+    @param meters float expressing lowest valid distance
+*/
+/**************************************************************************/
+void Adafruit_GPS::setDriftTolerance(nmea_float_t meters) {
+  driftTolerance = meters;
+}
+
+
+/**************************************************************************/
+/*!
     @brief Start the LOCUS logger
     @return True on success, false if it failed
 */

--- a/src/Adafruit_GPS.h
+++ b/src/Adafruit_GPS.h
@@ -105,6 +105,7 @@ public:
   char *lastNMEA(void);
   bool waitForSentence(const char *wait, uint8_t max = MAXWAITSENTENCE,
                        bool usingInterrupts = false);
+  void setDriftTolerance(nmea_float_t meters = 10.0);
   bool LOCUS_StartLogger(void);
   bool LOCUS_StopLogger(void);
   bool LOCUS_ReadStatus(void);
@@ -182,6 +183,17 @@ public:
 
   nmea_float_t latitudeDegrees;  ///< Latitude in decimal degrees
   nmea_float_t longitudeDegrees; ///< Longitude in decimal degrees
+  nmea_float_t driftTolerance = 10.0; ///< Threshold for updating lat/long...DegreesLocked (below)
+                                      ///< and tripDistance
+  nmea_float_t latitudeDegreesLocked;	///
+				    ///< Only updated if move more than drift tolerance
+				    ///< Floating point latitude value in degrees/minutes
+                         ///< as received from the GPS (DDMM.MMMM)
+  nmea_float_t longitudeDegreesLocked;		///
+					///< Only updated if move more than drift tolerance
+				     ///< Floating point longitude value in degrees/minutes
+                          ///< as received from the GPS (DDDMM.MMMM)
+  nmea_float_t tripDistance = 0.0;    ///< cumulative distance travelled using lat/long...DegreesLocked
   nmea_float_t geoidheight;      ///< Diff between geoid height and WGS84 height
   nmea_float_t altitude;         ///< Altitude in meters above MSL
   nmea_float_t speed;            ///< Current speed over ground in knots
@@ -251,6 +263,8 @@ private:
   bool parseFix(char *);
   bool parseAntenna(char *);
   bool isEmpty(char *pStart);
+  nmea_float_t degreesToRadians(nmea_float_t deg);
+  void updateTripMeter(nmea_float_t);
 
   // used by check() for validity tests, room for future expansion
   const char *sources[7] = {"II", "WI", "GP", "PG",


### PR DESCRIPTION
- Scope of change--i.e. what the change does and what parts
  of the code were modified.**

--   Changes to RMC processing

   Add trip distance functionality
   A new private variable 'driftTolerance' added initialized to 10.0 (meters)
   A new public variable 'tripDistance' to record cumulative distance
   A new pair of location variables 'latitudeDegreesLocked' and 'longitudeDegreesLocked'
   
   Distance 'd' is calculated between current fix and 'latitudeDegreesLocked' / 
   'longitudeDegreesLocked'.  If 'd' is greater than 'driftTolerance' then 'latitudeDegreesLocked'
   and 'longitudeDegreesLocked' are updated to reflect the current fix and tripDistance is
   increased by 'd'.  This is to filter out small changes in fix postion while actually stationary
   or moving slowly.

   RMC parsing only takes place if fix is valid i.e. 'A'.  To do otherwise does not make sense as
   there will be no data in the RMC sentance or would be unreliable anyway.
   
   'driftTolerance' can be set by calling ::setDriftTolerance(x) where x is specified in meters as a float.
   'tripDistance' can be reset to zero (or set to any other value)

--   Simplify parseCoords()
   Removed several steps and variables
   

  No limitations introduced 

  Code fully tested



