### PR TITLE
Update NMEA refs $PGTOP to $PCD for new modules

### DIFF
--- a/src/Adafruit_GPS.h
+++ b/src/Adafruit_GPS.h
@@ -257,7 +257,7 @@ private:
                             "GN", "P",  "ZZZ"}; ///< valid source ids
 #ifdef NMEA_EXTENSIONS
   const char *sentences_parsed[21] = {"GGA", "GLL", "GSA", "RMC", "DBT", "HDM",
-                                      "HDT", "MDA", "MTW", "MWV", "RMB", "TOP",
+                                      "HDT", "MDA", "MTW", "MWV", "RMB", "CD",
                                       "TXT", "VHW", "VLW", "VPW", "VWR", "WCV",
                                       "XTE", "ZZZ"}; ///< parseable sentence ids
   const char *sentences_known[15] = {
@@ -265,7 +265,7 @@ private:
       "RPM", "RSA", "VDR", "VTG", "ZDA", "ZZZ"}; ///< known, but not parseable
 #else // make the lists short to save memory
   const char *sentences_parsed[6] = {"GGA", "GLL", "GSA", "RMC",
-                                     "TOP", "ZZZ"}; ///< parseable sentence ids
+                                     "CD", "ZZZ"}; ///< parseable sentence ids
   const char *sentences_known[4] = {"DBT", "HDM", "HDT",
                                     "ZZZ"}; ///< known, but not parseable
 #endif

--- a/src/NMEA_parse.cpp
+++ b/src/NMEA_parse.cpp
@@ -165,12 +165,12 @@ bool Adafruit_GPS::parse(char *nmea) {
     if (!isEmpty(p))
       VDOP = atof(p); // last before checksum
 
-  } else if (!strcmp(thisSentence, "TOP")) { //*****************************TOP
+  } else if (!strcmp(thisSentence, "CD")) { //*****************************CD
     // See:
     // https://learn.adafruit.com/adafruit-ultimate-gps-featherwing/antenna-options
     // There is an output sentence that will tell you the status of the
     // antenna. $PGTOP,11,x where x is the status number. If x is 3 that means
-    // it is using the external antenna. If x is 2 it's using the internal
+    // it is using the external antenna. If x is 2 it's using the internal.
     p = strchr(p, ',') + 1;
     parseAntenna(p);
   }


### PR DESCRIPTION
Scope:
- Changes NMEA_parse.cpp and Adafruit_GPS.h. 3 lines total, renaming an old
value to a new one.

Known Limitations:
- Will break compatability with GPS modules before v3.1.

Fixes https://github.com/adafruit/Adafruit_GPS/issues/148