### PR TITLE
library.properties|Fix: Removed dependency on `SD`, due to various complications.

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,3 @@ paragraph=An interrupt-based GPS library for no-parsing-required use
 category=Sensors
 url=https://github.com/adafruit/Adafruit_GPS
 architectures=*
-depends=SD


### PR DESCRIPTION
1. This dependency is not used by the library only in 1 example, so it's not a true dependency.
2. The `SD`  dependency is ambigous:

```
Library Manager: Installing SD
Library Manager: Warning! More than one package has been found by SD requirements:
Library Manager:  - arduino-libraries/SD@1.3.0
Library Manager:  - adafruit/SD@0.0.0-alpha+sha.041f788250
Library Manager: Please specify detailed REQUIREMENTS using package owner and version (shown above) to avoid name conflicts
```
3. `ArduinoEspressif32` has a built-in `SD` library that will be overwritten by this dependency and can no longer be accessed. (.platformio/packages/framework-arduinoespressif32/libraries/SD/src/SD.h)
